### PR TITLE
Document Stripe vendor extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,90 @@
 This repository contains an [OpenAPI specification][openapi] for Stripe's API.
 Both JSON and YAML formats are included and available in the `spec` directory.
 
-## Fixtures
+## Vendor Extensions
 
-The repository also contains a set of test fixtures for API resources which can
-be used to create higher quality mocked responses. These are also located in
-the `spec` directory.
+The specification ships with a few vendor-specific fields to help represent
+information in ways that are difficult in OpenAPI by default.
 
-All API resources in the specification are tagged with a vendor-prefix
-attribute called `x-resourceId`. The value of the attribute is an identifier
-that can be used to find the associated fixture in one of the fixture data
-files.
+### `x-expandableFields`
 
-So for example:
+Resources include an `x-expandableFields` that contains a list of fields that
+are expandable by making an API request with an `expand` parameter. See
+[expanding objects][expand].
+
+For example:
+
+``` yaml
+definitions:
+  ...
+  charge:
+    ...
+    x-expandableFields:
+    - balance_transaction
+```
+
+### `x-expansionResources`
+
+Any expandable field within a resource contains a set of references to the
+resources that it might be expanded to.
+
+For example:
+
+``` yaml
+definitions:
+  ...
+  charge:
+    properties:
+      ...
+      balance_transaction:
+        description: ID of the balance transaction that describes the impact of this
+          charge on your account balance (not including refunds or disputes).
+        type:
+        - string
+        x-expansionResources:
+          oneOf:
+          - "$ref": "#/definitions/balance_transaction"
+```
+
+### `x-polymorphicResources`
+
+Some API responses are "polymorphic" in that they might return multiple types
+of resources which is a case that OpenAPI can't handle. In these cases the spec
+will reference a "synthetic" resource which is an aggregate of the properties
+common to all the possible resources. It will also include the field
+`x-polymorphicResources` which references those resources more precisely.
+
+For example:
+
+``` yaml
+definitions:
+  ...
+  external_account_source:
+    properties:
+      ...
+    x-polymorphicResources:
+      oneOf:
+      - "$ref": "#/definitions/bank_account"
+      - "$ref": "#/definitions/card"
+```
+
+### `x-resourceId` and Fixtures
+
+Resources include `x-resourceId` which is a canonical name for each resource.
+It can be used in conjunction with the files `openapi/fixtures.{json,yaml}` to
+look up a sample representation (otherwise known as a "fixture") of the
+resource.
+
+For example:
 
 ``` yaml
 # spec.yaml
 ---
 definitions:
-  invoice_line_item:
+  ...
+  charge:
     ...
-    x-resourceId: invoice_line_item
+    x-resourceId: charge
 
 # fixtures.yaml
 ---
@@ -43,6 +107,7 @@ Run the test suite:
 
     make
 
+[expand]: https://stripe.com/docs/api/java#expanding_objects
 [openapi]: https://www.openapis.org/
 
 <!--


### PR DESCRIPTION
Documents the various vendor extensions that the Stripe OpenAPI 2.0 spec
uses to represent non-standard things like expansions, polymorphic
resources, and fixtures.