### PR TITLE
Fixes a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stripe's OpenAPI Specification
 
 This repository contains an [OpenAPI specification][openapi] for Stripe's API.
-Both JSON and YAML formats are included and available in the `spec` directory.
+Both JSON and YAML formats are included and available in the `openapi` directory.
 
 ## Vendor Extensions
 


### PR DESCRIPTION
The directory containing the JSON and YAML specs is called 'openapi'
instead of 'spec'. This is now correctly reflected in the README.

Signed-off-by: zachwick <zach@zachwick.com>