### PR TITLE
Update OpenAPI spec and fixtures for upcoming product/plan split Stripe API version

### DIFF
--- a/openapi/fixtures2.json
+++ b/openapi/fixtures2.json
@@ -4,6 +4,7 @@
       "business_name": "Stripe.com",
       "charges_enabled": false,
       "country": "US",
+      "created": 1234567890,
       "debit_negative_balances": true,
       "decline_charge_on": {
         "avs_failure": true,
@@ -86,6 +87,12 @@
           "product_description",
           "support_phone",
           "tos_acceptance.date",
+          "tos_acceptance.ip",
+          "legal_entity.last_name",
+          "legal_entity.type",
+          "product_description",
+          "support_phone",
+          "tos_acceptance.date",
           "tos_acceptance.ip"
         ]
       }
@@ -98,6 +105,7 @@
       "business_name": "Stripe.com",
       "charges_enabled": false,
       "country": "US",
+      "created": 1234567890,
       "default_currency": "usd",
       "details_submitted": false,
       "display_name": "Stripe.com",
@@ -580,6 +588,7 @@
           "created": 1500057521,
           "currency": "usd",
           "description": "Chargeback withdrawal for ch_1AfYgX2eZvKYlo2CCaTJvvuE",
+          "exchange_rate": null,
           "fee": 1500,
           "fee_details": [
             {
@@ -677,6 +686,7 @@
           "date": 1510178229,
           "description": null,
           "discount": null,
+          "due_date": null,
           "ending_balance": null,
           "forgiven": false,
           "lines": {
@@ -708,7 +718,7 @@
                   "name": "Premium",
                   "object": "plan",
                   "statement_descriptor": null,
-                  "trial_period_days": 2
+                  "trial_period_days": null
                 },
                 "proration": false,
                 "quantity": 1,
@@ -919,11 +929,13 @@
       "amount_due": 1000,
       "attempt_count": 1,
       "attempted": true,
+      "billing": "charge_automatically",
       "charge": "ch_19yUQN2eZvKYlo2CQf7aWpSX",
       "closed": true,
       "currency": "usd",
       "customer": "cus_BPRjIOgTsY2CRb",
       "date": 1234567890,
+      "due_date": 1234567890,
       "ending_balance": 0,
       "forgiven": false,
       "id": "in_15kkGj2eZvKYlo2ChUKAUXNz",
@@ -932,7 +944,7 @@
           {
             "amount": 999,
             "currency": "usd",
-            "description": null,
+            "description": "1x Foo (at $1.00)",
             "discountable": true,
             "id": "sub_BQp67DDCYZaOON",
             "livemode": true,
@@ -954,9 +966,9 @@
               "livemode": false,
               "metadata": {
               },
-              "name": "Ruby Express",
+              "nickname": null,
               "object": "plan",
-              "statement_descriptor": null,
+              "product": "prod_BT1t06tZ3jBCHi",
               "trial_period_days": null
             },
             "proration": false,
@@ -974,6 +986,7 @@
       "metadata": {
       },
       "next_payment_attempt": 1234567890,
+      "number": "8f4ef0a41e-0001",
       "object": "invoice",
       "paid": true,
       "period_end": 1234567890,
@@ -1030,6 +1043,8 @@
       },
       "object": "transfer_reversal",
       "transfer": "tr_1BHo5W2eZvKYlo2CDlK5FCGc"
+    },
+    "light_account_logout": {
     },
     "login_link": {
       "created": 1234567890,
@@ -1198,14 +1213,15 @@
     "payout": {
       "amount": 200,
       "arrival_date": 1234567890,
+      "automatic": true,
       "balance_transaction": "txn_1B3kCO2eZvKYlo2CQHzTvqYJ",
       "created": 1234567890,
       "currency": "usd",
-      "destination": "acct_164wxjKbnvuxQXGu",
-      "failure_balance_transaction": "txn_1BGmS02eZvKYlo2C9f16WPBN",
+      "description": "STRIPE TRANSFER",
       "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
       "livemode": false,
       "metadata": {
+        "order_id": "6735"
       },
       "method": "standard",
       "object": "payout",
@@ -1223,8 +1239,8 @@
       "livemode": false,
       "metadata": {
       },
-      "name": "Ruby Express",
-      "object": "plan"
+      "object": "plan",
+      "product": "prod_BT1t06tZ3jBCHi"
     },
     "platform_earning": {
       "account": "acct_1032D82eZvKYlo2C",
@@ -1241,7 +1257,19 @@
       "refunded": false,
       "refunds": {
         "data": [
-
+          {
+            "amount": 10,
+            "balance_transaction": "txn_1BjP3P2eZvKYlo2CoRO62UDH",
+            "created": 1515750147,
+            "currency": "usd",
+            "fee": "fee_1BjP3OAhx0yxnhNSHCZSVKHs",
+            "id": "fr_C7eM84WByGcCVy",
+            "metadata": {
+              "ApprovedBy": "Robert",
+              "ApprovedReason": "Buckets!"
+            },
+            "object": "fee_refund"
+          }
         ],
         "has_more": false,
         "object": "list",
@@ -1251,12 +1279,15 @@
     },
     "product": {
       "attributes": [
-
+        "gender",
+        "size"
       ],
+      "caption": "test",
       "created": 1234567890,
       "deactivate_on": [
 
       ],
+      "description": "Comfortable cotton t-shirt",
       "id": "prod_AJ7gAXvktPRvvh",
       "images": [
 
@@ -1266,16 +1297,46 @@
       },
       "name": "Test",
       "object": "product",
+      "package_dimensions": {
+        "height": 1.25,
+        "length": 2.44,
+        "weight": 3.0,
+        "width": 4.0
+      },
       "skus": {
         "data": [
-
+          {
+            "active": true,
+            "attributes": {
+              "gender": "Unisex",
+              "size": "Medium"
+            },
+            "created": 1514875358,
+            "currency": "usd",
+            "id": "sku_C3rCQ7Eq4wRfLw",
+            "image": null,
+            "inventory": {
+              "quantity": 500,
+              "type": "finite",
+              "value": null
+            },
+            "livemode": false,
+            "metadata": {
+            },
+            "object": "sku",
+            "package_dimensions": null,
+            "price": 1500,
+            "product": "prod_BosWT9EsdzgjPn",
+            "updated": 1514875358
+          }
         ],
         "has_more": false,
         "object": "list",
         "total_count": 1,
         "url": "/v1/skus?product=prod_AJ7gAXvktPRvvh&active=true"
       },
-      "updated": 1234567890
+      "updated": 1234567890,
+      "url": "https://api.stripe.com/"
     },
     "refund": {
       "amount": 1000,
@@ -1352,10 +1413,69 @@
       "type": "bitcoin",
       "usage": "single_use"
     },
-    "source_transaction": {
-      "amount": 500,
-      "bitcoin": {
+    "source_mandate_notification": {
+      "amount": 1000,
+      "created": 1234567890,
+      "id": "srcmn_1BbniC2eZvKYlo2C9p3HU0dI",
+      "livemode": false,
+      "object": "source_mandate_notification",
+      "reason": "debit_initiated",
+      "source": {
+        "amount": null,
+        "client_secret": "src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI",
+        "created": 1513938307,
+        "currency": "eur",
+        "flow": "none",
+        "id": "src_1BbniB2eZvKYlo2Csqwsab9G",
+        "livemode": false,
+        "mandate": {
+          "acceptance": {
+            "date": null,
+            "ip": null,
+            "status": "pending",
+            "user_agent": null
+          },
+          "notification_method": "none",
+          "reference": "KX0W2TI6S5BMTEZI",
+          "url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI"
+        },
+        "metadata": {
+        },
+        "object": "source",
+        "owner": {
+          "address": null,
+          "email": null,
+          "name": "Mike Example",
+          "phone": null,
+          "verified_address": null,
+          "verified_email": null,
+          "verified_name": null,
+          "verified_phone": null
+        },
+        "sepa_debit": {
+          "bank_code": "37040044",
+          "branch_code": null,
+          "country": "DE",
+          "fingerprint": "5z3u9pLCmBK3gWER",
+          "last4": "3000",
+          "mandate_reference": "KX0W2TI6S5BMTEZI",
+          "mandate_url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI"
+        },
+        "statement_descriptor": null,
+        "status": "consumed",
+        "type": "sepa_debit",
+        "usage": "reusable"
       },
+      "status": "submitted",
+      "type": "sepa_debit"
+    },
+    "source_transaction": {
+      "ach_credit_transfer": {
+        "fingerprint": "7IK2FXdF6MLQrwOR",
+        "last4": "09e6",
+        "routing_number": "110000000"
+      },
+      "amount": 500,
       "created": 1234567890,
       "currency": "usd",
       "id": "srctxn_1BHbJc2eZvKYlo2CWq4JMX8S",
@@ -1365,6 +1485,7 @@
       "type": "bitcoin"
     },
     "subscription": {
+      "billing": "charge_automatically",
       "cancel_at_period_end": false,
       "canceled_at": 1234567890,
       "created": 1234567890,
@@ -1392,7 +1513,9 @@
               "metadata": {
               },
               "name": "Ruby Express",
+              "nickname": null,
               "object": "plan",
+              "product": "prod_BURz485SkjnwD8",
               "statement_descriptor": null,
               "trial_period_days": null
             },
@@ -1420,7 +1543,9 @@
         "metadata": {
         },
         "name": "Ruby Express",
+        "nickname": null,
         "object": "plan",
+        "product": "prod_BURz485SkjnwD8",
         "statement_descriptor": null,
         "trial_period_days": null
       },
@@ -1447,7 +1572,9 @@
         "metadata": {
         },
         "name": "Ruby Express",
+        "nickname": null,
         "object": "plan",
+        "product": "prod_BT1t06tZ3jBCHi",
         "statement_descriptor": null,
         "trial_period_days": null
       },
@@ -1534,6 +1661,7 @@
       "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
       "livemode": false,
       "metadata": {
+        "order_id": "6735"
       },
       "object": "transfer",
       "reversals": {
@@ -1622,11 +1750,13 @@
       "amount_due": 1000,
       "attempt_count": 1,
       "attempted": true,
+      "billing": "charge_automatically",
       "charge": "ch_19yUQN2eZvKYlo2CQf7aWpSX",
       "closed": true,
       "currency": "usd",
       "customer": "cus_BPRjIOgTsY2CRb",
       "date": 1234567890,
+      "due_date": 1234567890,
       "ending_balance": 0,
       "forgiven": false,
       "lines": {
@@ -1634,7 +1764,7 @@
           {
             "amount": 999,
             "currency": "usd",
-            "description": null,
+            "description": "Subscription to Quartz Starter ($9.99 per month)",
             "discountable": true,
             "id": "sub_9lNL2lSXI8nYEQ",
             "livemode": false,
@@ -1655,9 +1785,9 @@
               "livemode": false,
               "metadata": {
               },
-              "name": "Quartz Starter",
+              "nickname": null,
               "object": "plan",
-              "statement_descriptor": null,
+              "product": "prod_BTZg7dJsKNMND7",
               "trial_period_days": null
             },
             "proration": false,
@@ -1676,6 +1806,7 @@
       "metadata": {
       },
       "next_payment_attempt": 1234567890,
+      "number": "8f4ef0a41e-0001",
       "object": "invoice",
       "paid": true,
       "period_end": 1234567890,

--- a/openapi/fixtures2.yaml
+++ b/openapi/fixtures2.yaml
@@ -4,6 +4,7 @@ resources:
     business_name: Stripe.com
     charges_enabled: false
     country: US
+    created: 1234567890
     debit_negative_balances: true
     decline_charge_on:
       avs_failure: true
@@ -73,6 +74,12 @@ resources:
       - support_phone
       - tos_acceptance.date
       - tos_acceptance.ip
+      - legal_entity.last_name
+      - legal_entity.type
+      - product_description
+      - support_phone
+      - tos_acceptance.date
+      - tos_acceptance.ip
   account_debit_account:
     id: acct_1032D82eZvKYlo2C
     object: account
@@ -80,6 +87,7 @@ resources:
     business_name: Stripe.com
     charges_enabled: false
     country: US
+    created: 1234567890
     default_currency: usd
     details_submitted: false
     display_name: Stripe.com
@@ -443,6 +451,7 @@ resources:
       created: 1500057521
       currency: usd
       description: Chargeback withdrawal for ch_1AfYgX2eZvKYlo2CCaTJvvuE
+      exchange_rate: 
       fee: 1500
       fee_details:
       - amount: 1500
@@ -529,6 +538,7 @@ resources:
         date: 1510178229
         description: 
         discount: 
+        due_date: 
         ending_balance: 
         forgiven: false
         lines:
@@ -556,7 +566,7 @@ resources:
               name: Premium
               object: plan
               statement_descriptor: 
-              trial_period_days: 2
+              trial_period_days: 
             proration: false
             quantity: 1
             subscription: 
@@ -752,11 +762,13 @@ resources:
     amount_due: 1000
     attempt_count: 1
     attempted: true
+    billing: charge_automatically
     charge: ch_19yUQN2eZvKYlo2CQf7aWpSX
     closed: true
     currency: usd
     customer: cus_BPRjIOgTsY2CRb
     date: 1234567890
+    due_date: 1234567890
     ending_balance: 0
     forgiven: false
     id: in_15kkGj2eZvKYlo2ChUKAUXNz
@@ -764,7 +776,7 @@ resources:
       data:
       - amount: 999
         currency: usd
-        description: 
+        description: 1x Foo (at $1.00)
         discountable: true
         id: sub_BQp67DDCYZaOON
         livemode: true
@@ -783,9 +795,9 @@ resources:
           interval_count: 1
           livemode: false
           metadata: {}
-          name: Ruby Express
+          nickname: 
           object: plan
-          statement_descriptor: 
+          product: prod_BT1t06tZ3jBCHi
           trial_period_days: 
         proration: false
         quantity: 1
@@ -798,6 +810,7 @@ resources:
     livemode: false
     metadata: {}
     next_payment_attempt: 1234567890
+    number: 8f4ef0a41e-0001
     object: invoice
     paid: true
     period_end: 1234567890
@@ -846,6 +859,7 @@ resources:
     metadata: {}
     object: transfer_reversal
     transfer: tr_1BHo5W2eZvKYlo2CDlK5FCGc
+  light_account_logout: {}
   login_link:
     created: 1234567890
     object: login_link
@@ -978,14 +992,15 @@ resources:
   payout:
     amount: 200
     arrival_date: 1234567890
+    automatic: true
     balance_transaction: txn_1B3kCO2eZvKYlo2CQHzTvqYJ
     created: 1234567890
     currency: usd
-    destination: acct_164wxjKbnvuxQXGu
-    failure_balance_transaction: txn_1BGmS02eZvKYlo2C9f16WPBN
+    description: STRIPE TRANSFER
     id: tr_164xRv2eZvKYlo2CZxJZWm1E
     livemode: false
-    metadata: {}
+    metadata:
+      order_id: '6735'
     method: standard
     object: payout
     source_type: card
@@ -1000,8 +1015,8 @@ resources:
     interval_count: 1
     livemode: false
     metadata: {}
-    name: Ruby Express
     object: plan
+    product: prod_BT1t06tZ3jBCHi
   platform_earning:
     account: acct_1032D82eZvKYlo2C
     amount: 100
@@ -1016,28 +1031,67 @@ resources:
     object: application_fee
     refunded: false
     refunds:
-      data: []
+      data:
+      - amount: 10
+        balance_transaction: txn_1BjP3P2eZvKYlo2CoRO62UDH
+        created: 1515750147
+        currency: usd
+        fee: fee_1BjP3OAhx0yxnhNSHCZSVKHs
+        id: fr_C7eM84WByGcCVy
+        metadata:
+          ApprovedBy: Robert
+          ApprovedReason: Buckets!
+        object: fee_refund
       has_more: false
       object: list
       total_count: 0
       url: "/v1/application_fees/fee_1B3xSR2eZvKYlo2CusqnWWtU/refunds"
   product:
-    attributes: []
+    attributes:
+    - gender
+    - size
+    caption: test
     created: 1234567890
     deactivate_on: []
+    description: Comfortable cotton t-shirt
     id: prod_AJ7gAXvktPRvvh
     images: []
     livemode: false
     metadata: {}
     name: Test
     object: product
+    package_dimensions:
+      height: 1.25
+      length: 2.44
+      weight: 3.0
+      width: 4.0
     skus:
-      data: []
+      data:
+      - active: true
+        attributes:
+          gender: Unisex
+          size: Medium
+        created: 1514875358
+        currency: usd
+        id: sku_C3rCQ7Eq4wRfLw
+        image: 
+        inventory:
+          quantity: 500
+          type: finite
+          value: 
+        livemode: false
+        metadata: {}
+        object: sku
+        package_dimensions: 
+        price: 1500
+        product: prod_BosWT9EsdzgjPn
+        updated: 1514875358
       has_more: false
       object: list
       total_count: 1
       url: "/v1/skus?product=prod_AJ7gAXvktPRvvh&active=true"
     updated: 1234567890
+    url: https://api.stripe.com/
   refund:
     amount: 1000
     balance_transaction: txn_1BHr1p2eZvKYlo2C0eMVwL9d
@@ -1102,9 +1156,61 @@ resources:
     status: pending
     type: bitcoin
     usage: single_use
+  source_mandate_notification:
+    amount: 1000
+    created: 1234567890
+    id: srcmn_1BbniC2eZvKYlo2C9p3HU0dI
+    livemode: false
+    object: source_mandate_notification
+    reason: debit_initiated
+    source:
+      amount: 
+      client_secret: src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      created: 1513938307
+      currency: eur
+      flow: none
+      id: src_1BbniB2eZvKYlo2Csqwsab9G
+      livemode: false
+      mandate:
+        acceptance:
+          date: 
+          ip: 
+          status: pending
+          user_agent: 
+        notification_method: none
+        reference: KX0W2TI6S5BMTEZI
+        url: https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      metadata: {}
+      object: source
+      owner:
+        address: 
+        email: 
+        name: Mike Example
+        phone: 
+        verified_address: 
+        verified_email: 
+        verified_name: 
+        verified_phone: 
+      sepa_debit:
+        bank_code: '37040044'
+        branch_code: 
+        country: DE
+        fingerprint: 5z3u9pLCmBK3gWER
+        last4: '3000'
+        mandate_reference: KX0W2TI6S5BMTEZI
+        mandate_url: https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      statement_descriptor: 
+      status: consumed
+      type: sepa_debit
+      usage: reusable
+    status: submitted
+    type: sepa_debit
   source_transaction:
+    ach_credit_transfer:
+      fingerprint: 7IK2FXdF6MLQrwOR
+      last4: '09e6'
+      routing_number: '110000000'
     amount: 500
-    bitcoin: {}
     created: 1234567890
     currency: usd
     id: srctxn_1BHbJc2eZvKYlo2CWq4JMX8S
@@ -1113,6 +1219,7 @@ resources:
     source: src_1BHbJb2eZvKYlo2CF63xXuQp
     type: bitcoin
   subscription:
+    billing: charge_automatically
     cancel_at_period_end: false
     canceled_at: 1234567890
     created: 1234567890
@@ -1137,7 +1244,9 @@ resources:
           livemode: false
           metadata: {}
           name: Ruby Express
+          nickname: 
           object: plan
+          product: prod_BURz485SkjnwD8
           statement_descriptor: 
           trial_period_days: 
         quantity: 1
@@ -1159,7 +1268,9 @@ resources:
       livemode: false
       metadata: {}
       name: Ruby Express
+      nickname: 
       object: plan
+      product: prod_BURz485SkjnwD8
       statement_descriptor: 
       trial_period_days: 
     quantity: 1
@@ -1182,7 +1293,9 @@ resources:
       livemode: false
       metadata: {}
       name: Ruby Express
+      nickname: 
       object: plan
+      product: prod_BT1t06tZ3jBCHi
       statement_descriptor: 
       trial_period_days: 
     quantity: 1
@@ -1260,7 +1373,8 @@ resources:
     destination_payment: py_164xRvKbnvuxQXGuVFV2pZo1
     id: tr_164xRv2eZvKYlo2CZxJZWm1E
     livemode: false
-    metadata: {}
+    metadata:
+      order_id: '6735'
     object: transfer
     reversals:
       data:
@@ -1330,18 +1444,20 @@ resources:
     amount_due: 1000
     attempt_count: 1
     attempted: true
+    billing: charge_automatically
     charge: ch_19yUQN2eZvKYlo2CQf7aWpSX
     closed: true
     currency: usd
     customer: cus_BPRjIOgTsY2CRb
     date: 1234567890
+    due_date: 1234567890
     ending_balance: 0
     forgiven: false
     lines:
       data:
       - amount: 999
         currency: usd
-        description: 
+        description: Subscription to Quartz Starter ($9.99 per month)
         discountable: true
         id: sub_9lNL2lSXI8nYEQ
         livemode: false
@@ -1359,9 +1475,9 @@ resources:
           interval_count: 1
           livemode: false
           metadata: {}
-          name: Quartz Starter
+          nickname: 
           object: plan
-          statement_descriptor: 
+          product: prod_BTZg7dJsKNMND7
           trial_period_days: 
         proration: false
         quantity: 1
@@ -1375,6 +1491,7 @@ resources:
     livemode: false
     metadata: {}
     next_payment_attempt: 1234567890
+    number: 8f4ef0a41e-0001
     object: invoice
     paid: true
     period_end: 1234567890

--- a/openapi/fixtures3.json
+++ b/openapi/fixtures3.json
@@ -4,6 +4,7 @@
       "business_name": "Stripe.com",
       "charges_enabled": false,
       "country": "US",
+      "created": 1234567890,
       "debit_negative_balances": true,
       "decline_charge_on": {
         "avs_failure": true,
@@ -86,6 +87,12 @@
           "product_description",
           "support_phone",
           "tos_acceptance.date",
+          "tos_acceptance.ip",
+          "legal_entity.last_name",
+          "legal_entity.type",
+          "product_description",
+          "support_phone",
+          "tos_acceptance.date",
           "tos_acceptance.ip"
         ]
       }
@@ -98,6 +105,7 @@
       "business_name": "Stripe.com",
       "charges_enabled": false,
       "country": "US",
+      "created": 1234567890,
       "default_currency": "usd",
       "details_submitted": false,
       "display_name": "Stripe.com",
@@ -599,6 +607,7 @@
           "created": 1500057521,
           "currency": "usd",
           "description": "Chargeback withdrawal for ch_1AfYgX2eZvKYlo2CCaTJvvuE",
+          "exchange_rate": null,
           "fee": 1500,
           "fee_details": [
             {
@@ -696,6 +705,7 @@
           "date": 1510178234,
           "description": null,
           "discount": null,
+          "due_date": null,
           "ending_balance": null,
           "forgiven": false,
           "lines": {
@@ -727,7 +737,7 @@
                   "name": "Premium",
                   "object": "plan",
                   "statement_descriptor": null,
-                  "trial_period_days": 2
+                  "trial_period_days": null
                 },
                 "proration": false,
                 "quantity": 1,
@@ -943,11 +953,13 @@
       "amount_due": 1000,
       "attempt_count": 1,
       "attempted": true,
+      "billing": "charge_automatically",
       "charge": "ch_19yUQN2eZvKYlo2CQf7aWpSX",
       "closed": true,
       "currency": "usd",
       "customer": "cus_BPRjIOgTsY2CRb",
       "date": 1234567890,
+      "due_date": 1234567890,
       "ending_balance": 0,
       "forgiven": false,
       "id": "in_15kkGj2eZvKYlo2ChUKAUXNz",
@@ -956,7 +968,7 @@
           {
             "amount": 999,
             "currency": "usd",
-            "description": null,
+            "description": "1x Foo (at $1.00)",
             "discountable": true,
             "id": "sub_BQp6MLuprKbRgM",
             "livemode": true,
@@ -978,9 +990,9 @@
               "livemode": false,
               "metadata": {
               },
-              "name": "Ruby Express",
+              "nickname": null,
               "object": "plan",
-              "statement_descriptor": null,
+              "product": "prod_BT1t06tZ3jBCHi",
               "trial_period_days": null
             },
             "proration": false,
@@ -998,6 +1010,7 @@
       "metadata": {
       },
       "next_payment_attempt": 1234567890,
+      "number": "8f4ef0a41e-0001",
       "object": "invoice",
       "paid": true,
       "period_end": 1234567890,
@@ -1054,6 +1067,8 @@
       },
       "object": "transfer_reversal",
       "transfer": "tr_1BHo5W2eZvKYlo2CDlK5FCGc"
+    },
+    "light_account_logout": {
     },
     "login_link": {
       "created": 1234567890,
@@ -1222,14 +1237,15 @@
     "payout": {
       "amount": 200,
       "arrival_date": 1234567890,
+      "automatic": true,
       "balance_transaction": "txn_1B3kCO2eZvKYlo2CQHzTvqYJ",
       "created": 1234567890,
       "currency": "usd",
-      "destination": "acct_164wxjKbnvuxQXGu",
-      "failure_balance_transaction": "txn_1BGmS02eZvKYlo2C9f16WPBN",
+      "description": "STRIPE TRANSFER",
       "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
       "livemode": false,
       "metadata": {
+        "order_id": "6735"
       },
       "method": "standard",
       "object": "payout",
@@ -1247,8 +1263,8 @@
       "livemode": false,
       "metadata": {
       },
-      "name": "Ruby Express",
-      "object": "plan"
+      "object": "plan",
+      "product": "prod_BT1t06tZ3jBCHi"
     },
     "platform_earning": {
       "account": "acct_1032D82eZvKYlo2C",
@@ -1265,7 +1281,19 @@
       "refunded": false,
       "refunds": {
         "data": [
-
+          {
+            "amount": 10,
+            "balance_transaction": "txn_1BjP3P2eZvKYlo2CoRO62UDH",
+            "created": 1515750147,
+            "currency": "usd",
+            "fee": "fee_1BjP3OAhx0yxnhNSHCZSVKHs",
+            "id": "fr_C7eM84WByGcCVy",
+            "metadata": {
+              "ApprovedBy": "Robert",
+              "ApprovedReason": "Buckets!"
+            },
+            "object": "fee_refund"
+          }
         ],
         "has_more": false,
         "object": "list",
@@ -1275,12 +1303,15 @@
     },
     "product": {
       "attributes": [
-
+        "gender",
+        "size"
       ],
+      "caption": "test",
       "created": 1234567890,
       "deactivate_on": [
 
       ],
+      "description": "Comfortable cotton t-shirt",
       "id": "prod_AJ7gAXvktPRvvh",
       "images": [
 
@@ -1290,16 +1321,46 @@
       },
       "name": "Test",
       "object": "product",
+      "package_dimensions": {
+        "height": 1.25,
+        "length": 2.44,
+        "weight": 3.0,
+        "width": 4.0
+      },
       "skus": {
         "data": [
-
+          {
+            "active": true,
+            "attributes": {
+              "gender": "Unisex",
+              "size": "Medium"
+            },
+            "created": 1514875358,
+            "currency": "usd",
+            "id": "sku_C3rCQ7Eq4wRfLw",
+            "image": null,
+            "inventory": {
+              "quantity": 500,
+              "type": "finite",
+              "value": null
+            },
+            "livemode": false,
+            "metadata": {
+            },
+            "object": "sku",
+            "package_dimensions": null,
+            "price": 1500,
+            "product": "prod_BosWT9EsdzgjPn",
+            "updated": 1514875358
+          }
         ],
         "has_more": false,
         "object": "list",
         "total_count": 1,
         "url": "/v1/skus?product=prod_AJ7gAXvktPRvvh&active=true"
       },
-      "updated": 1234567890
+      "updated": 1234567890,
+      "url": "https://api.stripe.com/"
     },
     "refund": {
       "amount": 1000,
@@ -1376,10 +1437,69 @@
       "type": "bitcoin",
       "usage": "single_use"
     },
-    "source_transaction": {
-      "amount": 500,
-      "bitcoin": {
+    "source_mandate_notification": {
+      "amount": 1000,
+      "created": 1234567890,
+      "id": "srcmn_1BbniC2eZvKYlo2C9p3HU0dI",
+      "livemode": false,
+      "object": "source_mandate_notification",
+      "reason": "debit_initiated",
+      "source": {
+        "amount": null,
+        "client_secret": "src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI",
+        "created": 1513938307,
+        "currency": "eur",
+        "flow": "none",
+        "id": "src_1BbniB2eZvKYlo2Csqwsab9G",
+        "livemode": false,
+        "mandate": {
+          "acceptance": {
+            "date": null,
+            "ip": null,
+            "status": "pending",
+            "user_agent": null
+          },
+          "notification_method": "none",
+          "reference": "KX0W2TI6S5BMTEZI",
+          "url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI"
+        },
+        "metadata": {
+        },
+        "object": "source",
+        "owner": {
+          "address": null,
+          "email": null,
+          "name": "Mike Example",
+          "phone": null,
+          "verified_address": null,
+          "verified_email": null,
+          "verified_name": null,
+          "verified_phone": null
+        },
+        "sepa_debit": {
+          "bank_code": "37040044",
+          "branch_code": null,
+          "country": "DE",
+          "fingerprint": "5z3u9pLCmBK3gWER",
+          "last4": "3000",
+          "mandate_reference": "KX0W2TI6S5BMTEZI",
+          "mandate_url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI"
+        },
+        "statement_descriptor": null,
+        "status": "consumed",
+        "type": "sepa_debit",
+        "usage": "reusable"
       },
+      "status": "submitted",
+      "type": "sepa_debit"
+    },
+    "source_transaction": {
+      "ach_credit_transfer": {
+        "fingerprint": "7IK2FXdF6MLQrwOR",
+        "last4": "09e6",
+        "routing_number": "110000000"
+      },
+      "amount": 500,
       "created": 1234567890,
       "currency": "usd",
       "id": "srctxn_1BHbJf2eZvKYlo2Clmb1DOlc",
@@ -1389,6 +1509,7 @@
       "type": "bitcoin"
     },
     "subscription": {
+      "billing": "charge_automatically",
       "cancel_at_period_end": false,
       "canceled_at": 1234567890,
       "created": 1234567890,
@@ -1416,7 +1537,9 @@
               "metadata": {
               },
               "name": "Ruby Express",
+              "nickname": null,
               "object": "plan",
+              "product": "prod_BURz485SkjnwD8",
               "statement_descriptor": null,
               "trial_period_days": null
             },
@@ -1444,7 +1567,9 @@
         "metadata": {
         },
         "name": "Ruby Express",
+        "nickname": null,
         "object": "plan",
+        "product": "prod_BURz485SkjnwD8",
         "statement_descriptor": null,
         "trial_period_days": null
       },
@@ -1471,7 +1596,9 @@
         "metadata": {
         },
         "name": "Ruby Express",
+        "nickname": null,
         "object": "plan",
+        "product": "prod_BT1t06tZ3jBCHi",
         "statement_descriptor": null,
         "trial_period_days": null
       },
@@ -1558,6 +1685,7 @@
       "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
       "livemode": false,
       "metadata": {
+        "order_id": "6735"
       },
       "object": "transfer",
       "reversals": {
@@ -1646,11 +1774,13 @@
       "amount_due": 1000,
       "attempt_count": 1,
       "attempted": true,
+      "billing": "charge_automatically",
       "charge": "ch_19yUQN2eZvKYlo2CQf7aWpSX",
       "closed": true,
       "currency": "usd",
       "customer": "cus_BPRjIOgTsY2CRb",
       "date": 1234567890,
+      "due_date": 1234567890,
       "ending_balance": 0,
       "forgiven": false,
       "lines": {
@@ -1658,7 +1788,7 @@
           {
             "amount": 999,
             "currency": "usd",
-            "description": null,
+            "description": "Subscription to Quartz Starter ($9.99 per month)",
             "discountable": true,
             "id": "sub_9lNL2lSXI8nYEQ",
             "livemode": false,
@@ -1679,9 +1809,9 @@
               "livemode": false,
               "metadata": {
               },
-              "name": "Quartz Starter",
+              "nickname": null,
               "object": "plan",
-              "statement_descriptor": null,
+              "product": "prod_BTZg7dJsKNMND7",
               "trial_period_days": null
             },
             "proration": false,
@@ -1700,6 +1830,7 @@
       "metadata": {
       },
       "next_payment_attempt": 1234567890,
+      "number": "8f4ef0a41e-0001",
       "object": "invoice",
       "paid": true,
       "period_end": 1234567890,

--- a/openapi/fixtures3.yaml
+++ b/openapi/fixtures3.yaml
@@ -4,6 +4,7 @@ resources:
     business_name: Stripe.com
     charges_enabled: false
     country: US
+    created: 1234567890
     debit_negative_balances: true
     decline_charge_on:
       avs_failure: true
@@ -73,6 +74,12 @@ resources:
       - support_phone
       - tos_acceptance.date
       - tos_acceptance.ip
+      - legal_entity.last_name
+      - legal_entity.type
+      - product_description
+      - support_phone
+      - tos_acceptance.date
+      - tos_acceptance.ip
   account_debit_account:
     id: acct_1032D82eZvKYlo2C
     object: account
@@ -80,6 +87,7 @@ resources:
     business_name: Stripe.com
     charges_enabled: false
     country: US
+    created: 1234567890
     default_currency: usd
     details_submitted: false
     display_name: Stripe.com
@@ -462,6 +470,7 @@ resources:
       created: 1500057521
       currency: usd
       description: Chargeback withdrawal for ch_1AfYgX2eZvKYlo2CCaTJvvuE
+      exchange_rate: 
       fee: 1500
       fee_details:
       - amount: 1500
@@ -548,6 +557,7 @@ resources:
         date: 1510178234
         description: 
         discount: 
+        due_date: 
         ending_balance: 
         forgiven: false
         lines:
@@ -575,7 +585,7 @@ resources:
               name: Premium
               object: plan
               statement_descriptor: 
-              trial_period_days: 2
+              trial_period_days: 
             proration: false
             quantity: 1
             subscription: 
@@ -776,11 +786,13 @@ resources:
     amount_due: 1000
     attempt_count: 1
     attempted: true
+    billing: charge_automatically
     charge: ch_19yUQN2eZvKYlo2CQf7aWpSX
     closed: true
     currency: usd
     customer: cus_BPRjIOgTsY2CRb
     date: 1234567890
+    due_date: 1234567890
     ending_balance: 0
     forgiven: false
     id: in_15kkGj2eZvKYlo2ChUKAUXNz
@@ -788,7 +800,7 @@ resources:
       data:
       - amount: 999
         currency: usd
-        description: 
+        description: 1x Foo (at $1.00)
         discountable: true
         id: sub_BQp6MLuprKbRgM
         livemode: true
@@ -807,9 +819,9 @@ resources:
           interval_count: 1
           livemode: false
           metadata: {}
-          name: Ruby Express
+          nickname: 
           object: plan
-          statement_descriptor: 
+          product: prod_BT1t06tZ3jBCHi
           trial_period_days: 
         proration: false
         quantity: 1
@@ -822,6 +834,7 @@ resources:
     livemode: false
     metadata: {}
     next_payment_attempt: 1234567890
+    number: 8f4ef0a41e-0001
     object: invoice
     paid: true
     period_end: 1234567890
@@ -870,6 +883,7 @@ resources:
     metadata: {}
     object: transfer_reversal
     transfer: tr_1BHo5W2eZvKYlo2CDlK5FCGc
+  light_account_logout: {}
   login_link:
     created: 1234567890
     object: login_link
@@ -1002,14 +1016,15 @@ resources:
   payout:
     amount: 200
     arrival_date: 1234567890
+    automatic: true
     balance_transaction: txn_1B3kCO2eZvKYlo2CQHzTvqYJ
     created: 1234567890
     currency: usd
-    destination: acct_164wxjKbnvuxQXGu
-    failure_balance_transaction: txn_1BGmS02eZvKYlo2C9f16WPBN
+    description: STRIPE TRANSFER
     id: tr_164xRv2eZvKYlo2CZxJZWm1E
     livemode: false
-    metadata: {}
+    metadata:
+      order_id: '6735'
     method: standard
     object: payout
     source_type: card
@@ -1024,8 +1039,8 @@ resources:
     interval_count: 1
     livemode: false
     metadata: {}
-    name: Ruby Express
     object: plan
+    product: prod_BT1t06tZ3jBCHi
   platform_earning:
     account: acct_1032D82eZvKYlo2C
     amount: 100
@@ -1040,28 +1055,67 @@ resources:
     object: application_fee
     refunded: false
     refunds:
-      data: []
+      data:
+      - amount: 10
+        balance_transaction: txn_1BjP3P2eZvKYlo2CoRO62UDH
+        created: 1515750147
+        currency: usd
+        fee: fee_1BjP3OAhx0yxnhNSHCZSVKHs
+        id: fr_C7eM84WByGcCVy
+        metadata:
+          ApprovedBy: Robert
+          ApprovedReason: Buckets!
+        object: fee_refund
       has_more: false
       object: list
       total_count: 0
       url: "/v1/application_fees/fee_1B3xSU2eZvKYlo2CGSN17ITN/refunds"
   product:
-    attributes: []
+    attributes:
+    - gender
+    - size
+    caption: test
     created: 1234567890
     deactivate_on: []
+    description: Comfortable cotton t-shirt
     id: prod_AJ7gAXvktPRvvh
     images: []
     livemode: false
     metadata: {}
     name: Test
     object: product
+    package_dimensions:
+      height: 1.25
+      length: 2.44
+      weight: 3.0
+      width: 4.0
     skus:
-      data: []
+      data:
+      - active: true
+        attributes:
+          gender: Unisex
+          size: Medium
+        created: 1514875358
+        currency: usd
+        id: sku_C3rCQ7Eq4wRfLw
+        image: 
+        inventory:
+          quantity: 500
+          type: finite
+          value: 
+        livemode: false
+        metadata: {}
+        object: sku
+        package_dimensions: 
+        price: 1500
+        product: prod_BosWT9EsdzgjPn
+        updated: 1514875358
       has_more: false
       object: list
       total_count: 1
       url: "/v1/skus?product=prod_AJ7gAXvktPRvvh&active=true"
     updated: 1234567890
+    url: https://api.stripe.com/
   refund:
     amount: 1000
     balance_transaction: txn_1BHr1p2eZvKYlo2C0eMVwL9d
@@ -1126,9 +1180,61 @@ resources:
     status: pending
     type: bitcoin
     usage: single_use
+  source_mandate_notification:
+    amount: 1000
+    created: 1234567890
+    id: srcmn_1BbniC2eZvKYlo2C9p3HU0dI
+    livemode: false
+    object: source_mandate_notification
+    reason: debit_initiated
+    source:
+      amount: 
+      client_secret: src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      created: 1513938307
+      currency: eur
+      flow: none
+      id: src_1BbniB2eZvKYlo2Csqwsab9G
+      livemode: false
+      mandate:
+        acceptance:
+          date: 
+          ip: 
+          status: pending
+          user_agent: 
+        notification_method: none
+        reference: KX0W2TI6S5BMTEZI
+        url: https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      metadata: {}
+      object: source
+      owner:
+        address: 
+        email: 
+        name: Mike Example
+        phone: 
+        verified_address: 
+        verified_email: 
+        verified_name: 
+        verified_phone: 
+      sepa_debit:
+        bank_code: '37040044'
+        branch_code: 
+        country: DE
+        fingerprint: 5z3u9pLCmBK3gWER
+        last4: '3000'
+        mandate_reference: KX0W2TI6S5BMTEZI
+        mandate_url: https://hooks.stripe.com/adapter/sepa_debit/file/src_1BbniB2eZvKYlo2Csqwsab9G/src_client_secret_BznIb8Yqq6RvtW5KDJDUFqAI
+      statement_descriptor: 
+      status: consumed
+      type: sepa_debit
+      usage: reusable
+    status: submitted
+    type: sepa_debit
   source_transaction:
+    ach_credit_transfer:
+      fingerprint: 7IK2FXdF6MLQrwOR
+      last4: '09e6'
+      routing_number: '110000000'
     amount: 500
-    bitcoin: {}
     created: 1234567890
     currency: usd
     id: srctxn_1BHbJf2eZvKYlo2Clmb1DOlc
@@ -1137,6 +1243,7 @@ resources:
     source: src_1BHbJf2eZvKYlo2C1nVKTeU7
     type: bitcoin
   subscription:
+    billing: charge_automatically
     cancel_at_period_end: false
     canceled_at: 1234567890
     created: 1234567890
@@ -1161,7 +1268,9 @@ resources:
           livemode: false
           metadata: {}
           name: Ruby Express
+          nickname: 
           object: plan
+          product: prod_BURz485SkjnwD8
           statement_descriptor: 
           trial_period_days: 
         quantity: 1
@@ -1183,7 +1292,9 @@ resources:
       livemode: false
       metadata: {}
       name: Ruby Express
+      nickname: 
       object: plan
+      product: prod_BURz485SkjnwD8
       statement_descriptor: 
       trial_period_days: 
     quantity: 1
@@ -1206,7 +1317,9 @@ resources:
       livemode: false
       metadata: {}
       name: Ruby Express
+      nickname: 
       object: plan
+      product: prod_BT1t06tZ3jBCHi
       statement_descriptor: 
       trial_period_days: 
     quantity: 1
@@ -1284,7 +1397,8 @@ resources:
     destination_payment: py_164xRvKbnvuxQXGuVFV2pZo1
     id: tr_164xRv2eZvKYlo2CZxJZWm1E
     livemode: false
-    metadata: {}
+    metadata:
+      order_id: '6735'
     object: transfer
     reversals:
       data:
@@ -1354,18 +1468,20 @@ resources:
     amount_due: 1000
     attempt_count: 1
     attempted: true
+    billing: charge_automatically
     charge: ch_19yUQN2eZvKYlo2CQf7aWpSX
     closed: true
     currency: usd
     customer: cus_BPRjIOgTsY2CRb
     date: 1234567890
+    due_date: 1234567890
     ending_balance: 0
     forgiven: false
     lines:
       data:
       - amount: 999
         currency: usd
-        description: 
+        description: Subscription to Quartz Starter ($9.99 per month)
         discountable: true
         id: sub_9lNL2lSXI8nYEQ
         livemode: false
@@ -1383,9 +1499,9 @@ resources:
           interval_count: 1
           livemode: false
           metadata: {}
-          name: Quartz Starter
+          nickname: 
           object: plan
-          statement_descriptor: 
+          product: prod_BTZg7dJsKNMND7
           trial_period_days: 
         proration: false
         quantity: 1
@@ -1399,6 +1515,7 @@ resources:
     livemode: false
     metadata: {}
     next_payment_attempt: 1234567890
+    number: 8f4ef0a41e-0001
     object: invoice
     paid: true
     period_end: 1234567890

--- a/openapi/spec2.json
+++ b/openapi/spec2.json
@@ -6,19 +6,19 @@
     "account": {
       "properties": {
         "business_name": {
-          "description": "The publicly visible name of the business.",
+          "description": "The publicly visible name of the business",
           "type": "string"
         },
         "business_url": {
-          "description": "The publicly visible website of the business.",
+          "description": "The publicly visible website of the business",
           "type": "string"
         },
         "charges_enabled": {
-          "description": "Whether the account can create live charges.",
+          "description": "Whether the account can create live charges",
           "type": "boolean"
         },
         "country": {
-          "description": "The country of the account.",
+          "description": "The country of the account",
           "type": "string"
         },
         "created": {
@@ -26,22 +26,22 @@
           "type": "integer"
         },
         "debit_negative_balances": {
-          "description": "Whether Stripe will attempt to reclaim negative account balances from this account's bank account.",
+          "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
           "type": "boolean"
         },
         "decline_charge_on": {
           "$ref": "#/definitions/account_decline_charge_on"
         },
         "default_currency": {
-          "description": "The currency this account has chosen to use as the default.",
+          "description": "The currency this account has chosen to use as the default",
           "type": "string"
         },
         "details_submitted": {
-          "description": "Whether account details have been submitted yet. Standard accounts cannot receive transfers before this is true.",
+          "description": "Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.",
           "type": "boolean"
         },
         "display_name": {
-          "description": "The display name for this account. This is used on the Stripe dashboard to help you differentiate between accounts.",
+          "description": "The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts.",
           "type": "string"
         },
         "email": {
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "external_accounts": {
-          "description": "External accounts (bank accounts and/or cards) currently attached to this account.",
+          "description": "External accounts (bank accounts and debit cards) currently attached to this account",
           "properties": {
             "data": {
               "description": "The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards.",
@@ -108,38 +108,38 @@
           "$ref": "#/definitions/transfer_schedule"
         },
         "payout_statement_descriptor": {
-          "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+          "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
           "type": "string"
         },
         "payouts_enabled": {
-          "description": "Whether Stripe will send automatic transfers for this account. This is only false when Stripe is waiting for additional information from the account holder.",
+          "description": "Whether Stripe can send payouts to this account",
           "type": "boolean"
         },
         "product_description": {
-          "description": "An internal-only description of the product or service provided. This is used by Stripe in the event the account gets flagged for potential fraud.",
+          "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
           "type": "string"
         },
         "statement_descriptor": {
-          "description": "The text that will appear on credit card statements.",
+          "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
           "type": "string"
         },
         "support_email": {
-          "description": "A publicly shareable email address that can be reached for support for this account.",
+          "description": "A publicly shareable support email address for the business",
           "type": "string"
         },
         "support_phone": {
-          "description": "The publicly visible support phone number for the business.",
+          "description": "A publicly shareable support phone number for the business",
           "type": "string"
         },
         "timezone": {
-          "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
+          "description": "The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
           "type": "string"
         },
         "tos_acceptance": {
           "$ref": "#/definitions/account_tos_acceptance"
         },
         "type": {
-          "description": "The type of the Stripe account. Can be `standard`, `express`, or `custom`.",
+          "description": "The Stripe account type. Can be `standard`, `express`, or `custom`.",
           "type": "string"
         },
         "verification": {
@@ -196,11 +196,11 @@
     "account_decline_charge_on": {
       "properties": {
         "avs_failure": {
-          "description": "Whether Stripe should automatically decline charges with an incorrect ZIP or postal code. This setting only applies if a card includes a ZIP or postal code and the bank specifically marks it as failed.",
+          "description": "Whether Stripe should automatically decline charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and the bank specifically marks it as failed.",
           "type": "boolean"
         },
         "cvc_failure": {
-          "description": "Whether Stripe should automatically decline charges with an incorrect CVC. This setting only applies if a card includes a CVC and the bank specifically marks it as failed.",
+          "description": "Whether Stripe should automatically decline charges with an incorrect CVC. This setting only applies when a CVC is provided and the bank specifically marks it as failed.",
           "type": "boolean"
         }
       },
@@ -217,15 +217,15 @@
     "account_tos_acceptance": {
       "properties": {
         "date": {
-          "description": "The timestamp when the account owner accepted Stripe's terms.",
+          "description": "The Unix timestamp marking when the Stripe Services Agreement was accepted by the account representative",
           "type": "integer"
         },
         "ip": {
-          "description": "The IP address from which the account owner accepted Stripe's terms.",
+          "description": "The IP address from which the Stripe Services Agreement was accepted by the account representative",
           "type": "string"
         },
         "user_agent": {
-          "description": "The user agent of the browser from which the user accepted Stripe's terms.",
+          "description": "The user agent of the browser from which the Stripe Services Agreement was accepted by the account representative",
           "type": "string"
         }
       },
@@ -238,15 +238,15 @@
     "account_verification": {
       "properties": {
         "disabled_reason": {
-          "description": "A string describing the reason for this account being unable to charge and/or transfer, if that is the case. Possible values are `rejected.fraud`, `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`, `listed`, `under_review`, or `other`.",
+          "description": "A string describing the reason for this account being unable to create charges or receive payouts, if that is the case. Can be `rejected.fraud`, `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`, `listed`, `under_review`, or `other`.",
           "type": "string"
         },
         "due_by": {
-          "description": "At what time the `fields_needed` must be provided. If this date is in the past, the account is already in bad standing, and providing `fields_needed` is necessary to re-enable transfers and prevent other consequences. If this date is in the future, `fields_needed` must be provided to ensure the account remains in good standing.",
+          "description": "By what time the `fields_needed` must be provided. If this date is in the past, the account is already in bad standing, and providing `fields_needed` is necessary to re-enable payouts and prevent other consequences. If this date is in the future, `fields_needed` must be provided to ensure the account remains in good standing.",
           "type": "integer"
         },
         "fields_needed": {
-          "description": "Field names that need to be provided for the account to remain in good standing. Nested fields are separated by \".\" (for example, \"legal_entity.first_name\").",
+          "description": "Field names that need to be provided for the account to remain in good standing. Nested fields are separated by `.` (for example, `legal_entity.first_name`).",
           "type": "array"
         }
       },
@@ -262,19 +262,19 @@
     "account_with_keys": {
       "properties": {
         "business_name": {
-          "description": "The publicly visible name of the business.",
+          "description": "The publicly visible name of the business",
           "type": "string"
         },
         "business_url": {
-          "description": "The publicly visible website of the business.",
+          "description": "The publicly visible website of the business",
           "type": "string"
         },
         "charges_enabled": {
-          "description": "Whether the account can create live charges.",
+          "description": "Whether the account can create live charges",
           "type": "boolean"
         },
         "country": {
-          "description": "The country of the account.",
+          "description": "The country of the account",
           "type": "string"
         },
         "created": {
@@ -282,22 +282,22 @@
           "type": "integer"
         },
         "debit_negative_balances": {
-          "description": "Whether Stripe will attempt to reclaim negative account balances from this account's bank account.",
+          "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
           "type": "boolean"
         },
         "decline_charge_on": {
           "$ref": "#/definitions/account_decline_charge_on"
         },
         "default_currency": {
-          "description": "The currency this account has chosen to use as the default.",
+          "description": "The currency this account has chosen to use as the default",
           "type": "string"
         },
         "details_submitted": {
-          "description": "Whether account details have been submitted yet. Standard accounts cannot receive transfers before this is true.",
+          "description": "Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.",
           "type": "boolean"
         },
         "display_name": {
-          "description": "The display name for this account. This is used on the Stripe dashboard to help you differentiate between accounts.",
+          "description": "The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts.",
           "type": "string"
         },
         "email": {
@@ -305,7 +305,7 @@
           "type": "string"
         },
         "external_accounts": {
-          "description": "External accounts (bank accounts and/or cards) currently attached to this account.",
+          "description": "External accounts (bank accounts and debit cards) currently attached to this account",
           "properties": {
             "data": {
               "description": "The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards.",
@@ -367,38 +367,38 @@
           "$ref": "#/definitions/transfer_schedule"
         },
         "payout_statement_descriptor": {
-          "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+          "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
           "type": "string"
         },
         "payouts_enabled": {
-          "description": "Whether Stripe will send automatic transfers for this account. This is only false when Stripe is waiting for additional information from the account holder.",
+          "description": "Whether Stripe can send payouts to this account",
           "type": "boolean"
         },
         "product_description": {
-          "description": "An internal-only description of the product or service provided. This is used by Stripe in the event the account gets flagged for potential fraud.",
+          "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
           "type": "string"
         },
         "statement_descriptor": {
-          "description": "The text that will appear on credit card statements.",
+          "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
           "type": "string"
         },
         "support_email": {
-          "description": "A publicly shareable email address that can be reached for support for this account.",
+          "description": "A publicly shareable support email address for the business",
           "type": "string"
         },
         "support_phone": {
-          "description": "The publicly visible support phone number for the business.",
+          "description": "A publicly shareable support phone number for the business",
           "type": "string"
         },
         "timezone": {
-          "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
+          "description": "The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
           "type": "string"
         },
         "tos_acceptance": {
           "$ref": "#/definitions/account_tos_acceptance"
         },
         "type": {
-          "description": "The type of the Stripe account. Can be `standard`, `express`, or `custom`.",
+          "description": "The Stripe account type. Can be `standard`, `express`, or `custom`.",
           "type": "string"
         },
         "verification": {
@@ -4487,8 +4487,8 @@
           "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
           "type": "object"
         },
-        "name": {
-          "description": "Display name of the plan.",
+        "nickname": {
+          "description": "A brief description of the plan, hidden from customers.",
           "type": "string"
         },
         "object": {
@@ -4498,8 +4498,8 @@
           ],
           "type": "string"
         },
-        "statement_descriptor": {
-          "description": "Displayed on customer statements when their card is charged.",
+        "product": {
+          "description": "The product whose pricing this plan determines.",
           "type": "string"
         }
       },
@@ -4511,7 +4511,6 @@
         "interval_count",
         "livemode",
         "metadata",
-        "name",
         "object"
       ],
       "title": "Plan",
@@ -4941,6 +4940,14 @@
           "x-expandableFields": [
             "data"
           ]
+        },
+        "statement_descriptor": {
+          "description": "Extra information about a product which will appear on your customer's credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used. Only available on products of type=`service`.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of the product. The product is either of type `good`, which is eligible for use with Orders and SKUs, or `service`, which is eligible for use with Subscriptions and Plans.",
+          "type": "string"
         },
         "updated": {
           "type": "integer"
@@ -5673,6 +5680,64 @@
       "x-expandableFields": [
 
       ]
+    },
+    "source_mandate_notification": {
+      "properties": {
+        "amount": {
+          "description": "Amount associated with the mandate notification. The amount is expressed in the currency of the underlying Source. Set if the notification type is `debit_initiated`.",
+          "type": "integer"
+        },
+        "created": {
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "type": "integer"
+        },
+        "id": {
+          "description": "Unique identifier for the object.",
+          "type": "string"
+        },
+        "livemode": {
+          "description": "Flag indicating whether the object exists in live mode or test mode.",
+          "type": "boolean"
+        },
+        "object": {
+          "description": "String representing the object's type. Objects of the same type share the same value.",
+          "enum": [
+            "source_mandate_notification"
+          ],
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason of the mandate notification.",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        },
+        "status": {
+          "description": "The status of the mandate notification.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of source this mandate notification is attached to.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "created",
+        "id",
+        "livemode",
+        "object",
+        "reason",
+        "source",
+        "status",
+        "type"
+      ],
+      "title": "SourceMandateNotification",
+      "type": "object",
+      "x-expandableFields": [
+        "source"
+      ],
+      "x-resourceId": "source_mandate_notification"
     },
     "source_owner": {
       "properties": {
@@ -7451,7 +7516,7 @@
     "description": "The Stripe REST API. Please see https://stripe.com/docs/api for more details.",
     "termsOfService": "https://stripe.com/us/terms/",
     "title": "Stripe API",
-    "version": "2017-12-14"
+    "version": "2018-01-15"
   },
   "paths": {
     "/v1/3d_secure": {
@@ -7607,7 +7672,7 @@
             "type": "array"
           },
           {
-            "description": "The identifier of the account to be retrieved. If none is provided, will default to the account of the API key.",
+            "description": "The identifier of the account to retrieve. If none is provided, the account associated with the API key is returned.",
             "in": "query",
             "name": "account",
             "required": false,
@@ -7654,19 +7719,19 @@
                   "type": "string"
                 },
                 "business_primary_color": {
-                  "description": "A CSS hex color value representing the primary branding color for this account.",
+                  "description": "A CSS hex color value representing the primary branding color for this account",
                   "type": "string"
                 },
                 "business_url": {
-                  "description": "The URL that best shows the service or product provided for this account.",
+                  "description": "The URL that best shows the service or product provided by this account",
                   "type": "string"
                 },
                 "debit_negative_balances": {
-                  "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                  "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                   "type": "boolean"
                 },
                 "decline_charge_on": {
-                  "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                  "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                   "properties": {
                     "avs_failure": {
                       "type": "boolean"
@@ -7683,7 +7748,7 @@
                   "type": "string"
                 },
                 "email": {
-                  "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                  "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                   "type": "string"
                 },
                 "expand": {
@@ -7694,10 +7759,10 @@
                   "type": "array"
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                 },
                 "legal_entity": {
-                  "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                  "description": "Information about the legal entity itself, including about the associated account representative",
                   "properties": {
                     "additional_owners": {
                       "properties": {
@@ -10150,11 +10215,11 @@
                   "type": "object"
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                   "type": "object"
                 },
                 "payout_schedule": {
-                  "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                  "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                   "properties": {
                     "delay_days": {
                       "type": "integer"
@@ -10189,39 +10254,31 @@
                   "type": "object"
                 },
                 "payout_statement_descriptor": {
-                  "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                  "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                   "type": "string"
                 },
                 "product_description": {
-                  "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                  "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                   "type": "string"
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                  "type": "string"
-                },
-                "statement_descriptor_kana": {
-                  "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                  "type": "string"
-                },
-                "statement_descriptor_kanji": {
-                  "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                  "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                   "type": "string"
                 },
                 "support_email": {
-                  "description": "A publicly shareable email address that can be reached for support for this account.",
+                  "description": "A publicly shareable support email address for the business",
                   "type": "string"
                 },
                 "support_phone": {
-                  "description": "A publicly shareable phone number that can be reached for support for this account.",
+                  "description": "A publicly shareable support phone number for the business",
                   "type": "string"
                 },
                 "support_url": {
-                  "description": "A publicly shareable URL that can be reached for support for this account.",
+                  "description": "A publicly shareable URL that provides support for this account",
                   "type": "string"
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                  "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                   "properties": {
                     "date": {
                       "type": "integer"
@@ -10273,7 +10330,7 @@
             "schema": {
               "properties": {
                 "default_for_currency": {
-                  "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                  "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                   "type": "boolean"
                 },
                 "expand": {
@@ -10287,7 +10344,7 @@
                   "description": "This string to be replaced by DocSpecGenerator."
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                   "type": "object"
                 }
               },
@@ -10396,7 +10453,7 @@
         "operationId": "UpdateAccountExternalAccount",
         "parameters": [
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -10573,7 +10630,7 @@
             "schema": {
               "properties": {
                 "default_for_currency": {
-                  "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                  "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                   "type": "boolean"
                 },
                 "expand": {
@@ -10587,7 +10644,7 @@
                   "description": "This string to be replaced by DocSpecGenerator."
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                   "type": "object"
                 }
               },
@@ -10696,7 +10753,7 @@
         "operationId": "UpdateAccountExternalAccount",
         "parameters": [
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -10876,7 +10933,7 @@
     },
     "/v1/accounts": {
       "get": {
-        "description": "<p>Returns a list of accounts connected to your platform via <a href=\"/docs/connect\">Connect</a>. If you’re not a platform, the list will be empty.</p>",
+        "description": "<p>Returns a list of accounts connected to your platform via <a href=\"/docs/connect\">Connect</a>. If you’re not a platform, the list is empty.</p>",
         "operationId": "AllAccount",
         "parameters": [
           {
@@ -10980,22 +11037,22 @@
                   "type": "string"
                 },
                 "business_primary_color": {
-                  "description": "A CSS hex color value representing the primary branding color for this account.",
+                  "description": "A CSS hex color value representing the primary branding color for this account",
                   "type": "string"
                 },
                 "business_url": {
-                  "description": "The URL that best shows the service or product provided for this account.",
+                  "description": "The URL that best shows the service or product provided by this account",
                   "type": "string"
                 },
                 "country": {
                   "type": "string"
                 },
                 "debit_negative_balances": {
-                  "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                  "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                   "type": "boolean"
                 },
                 "decline_charge_on": {
-                  "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                  "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                   "properties": {
                     "avs_failure": {
                       "type": "boolean"
@@ -11015,7 +11072,7 @@
                   "type": "string"
                 },
                 "email": {
-                  "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                  "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                   "type": "string"
                 },
                 "expand": {
@@ -11026,13 +11083,13 @@
                   "type": "array"
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                 },
                 "from_recipient": {
                   "type": "string"
                 },
                 "legal_entity": {
-                  "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                  "description": "Information about the legal entity itself, including about the associated account representative",
                   "properties": {
                     "additional_owners": {
                       "properties": {
@@ -13488,11 +13545,11 @@
                   "type": "boolean"
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                   "type": "object"
                 },
                 "payout_schedule": {
-                  "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                  "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                   "properties": {
                     "delay_days": {
                       "type": "integer"
@@ -13527,42 +13584,34 @@
                   "type": "object"
                 },
                 "payout_statement_descriptor": {
-                  "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                  "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                   "type": "string"
                 },
                 "primary_user": {
                   "type": "string"
                 },
                 "product_description": {
-                  "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                  "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                   "type": "string"
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                  "type": "string"
-                },
-                "statement_descriptor_kana": {
-                  "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                  "type": "string"
-                },
-                "statement_descriptor_kanji": {
-                  "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                  "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                   "type": "string"
                 },
                 "support_email": {
-                  "description": "A publicly shareable email address that can be reached for support for this account.",
+                  "description": "A publicly shareable support email address for the business",
                   "type": "string"
                 },
                 "support_phone": {
-                  "description": "A publicly shareable phone number that can be reached for support for this account.",
+                  "description": "A publicly shareable support phone number for the business",
                   "type": "string"
                 },
                 "support_url": {
-                  "description": "A publicly shareable URL that can be reached for support for this account.",
+                  "description": "A publicly shareable URL that provides support for this account",
                   "type": "string"
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                  "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                   "properties": {
                     "date": {
                       "type": "integer"
@@ -13666,7 +13715,7 @@
             "type": "array"
           },
           {
-            "description": "The identifier of the account to be retrieved. If none is provided, will default to the account of the API key.",
+            "description": "The identifier of the account to retrieve. If none is provided, the account associated with the API key is returned.",
             "in": "path",
             "name": "account",
             "required": true,
@@ -13716,19 +13765,19 @@
                   "type": "string"
                 },
                 "business_primary_color": {
-                  "description": "A CSS hex color value representing the primary branding color for this account.",
+                  "description": "A CSS hex color value representing the primary branding color for this account",
                   "type": "string"
                 },
                 "business_url": {
-                  "description": "The URL that best shows the service or product provided for this account.",
+                  "description": "The URL that best shows the service or product provided by this account",
                   "type": "string"
                 },
                 "debit_negative_balances": {
-                  "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                  "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                   "type": "boolean"
                 },
                 "decline_charge_on": {
-                  "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                  "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                   "properties": {
                     "avs_failure": {
                       "type": "boolean"
@@ -13745,7 +13794,7 @@
                   "type": "string"
                 },
                 "email": {
-                  "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                  "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                   "type": "string"
                 },
                 "expand": {
@@ -13756,10 +13805,10 @@
                   "type": "array"
                 },
                 "external_account": {
-                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                  "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                 },
                 "legal_entity": {
-                  "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                  "description": "Information about the legal entity itself, including about the associated account representative",
                   "properties": {
                     "additional_owners": {
                       "properties": {
@@ -16212,11 +16261,11 @@
                   "type": "object"
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                   "type": "object"
                 },
                 "payout_schedule": {
-                  "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                  "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                   "properties": {
                     "delay_days": {
                       "type": "integer"
@@ -16251,39 +16300,31 @@
                   "type": "object"
                 },
                 "payout_statement_descriptor": {
-                  "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                  "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                   "type": "string"
                 },
                 "product_description": {
-                  "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                  "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                   "type": "string"
                 },
                 "statement_descriptor": {
-                  "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                  "type": "string"
-                },
-                "statement_descriptor_kana": {
-                  "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                  "type": "string"
-                },
-                "statement_descriptor_kanji": {
-                  "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                  "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                   "type": "string"
                 },
                 "support_email": {
-                  "description": "A publicly shareable email address that can be reached for support for this account.",
+                  "description": "A publicly shareable support email address for the business",
                   "type": "string"
                 },
                 "support_phone": {
-                  "description": "A publicly shareable phone number that can be reached for support for this account.",
+                  "description": "A publicly shareable support phone number for the business",
                   "type": "string"
                 },
                 "support_url": {
-                  "description": "A publicly shareable URL that can be reached for support for this account.",
+                  "description": "A publicly shareable URL that provides support for this account",
                   "type": "string"
                 },
                 "tos_acceptance": {
-                  "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                  "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                   "properties": {
                     "date": {
                       "type": "integer"
@@ -16341,7 +16382,7 @@
             "schema": {
               "properties": {
                 "default_for_currency": {
-                  "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                  "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                   "type": "boolean"
                 },
                 "expand": {
@@ -16355,7 +16396,7 @@
                   "description": "This string to be replaced by DocSpecGenerator."
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                   "type": "object"
                 }
               },
@@ -16482,7 +16523,7 @@
             "type": "string"
           },
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -16671,7 +16712,7 @@
             "schema": {
               "properties": {
                 "default_for_currency": {
-                  "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                  "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                   "type": "boolean"
                 },
                 "expand": {
@@ -16685,7 +16726,7 @@
                   "description": "This string to be replaced by DocSpecGenerator."
                 },
                 "metadata": {
-                  "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                  "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                   "type": "object"
                 }
               },
@@ -16812,7 +16853,7 @@
             "type": "string"
           },
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -16996,7 +17037,7 @@
         "operationId": "AccountReject",
         "parameters": [
           {
-            "description": "The identifier of the account to be rejected.",
+            "description": "The identifier of the account to reject",
             "in": "path",
             "name": "account",
             "required": true,
@@ -17017,7 +17058,7 @@
                   "type": "array"
                 },
                 "reason": {
-                  "description": "The reason for rejecting the account. May be one of `fraud`, `terms_of_service`, or `other`.",
+                  "description": "The reason for rejecting the account. Can be `fraud`, `terms_of_service`, or `other`.",
                   "type": "string"
                 }
               },
@@ -18657,7 +18698,7 @@
         }
       },
       "post": {
-        "description": "<p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>, <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>",
+        "description": "<p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>customer</code>, <code>description</code>, <code>fraud_details</code>, <code>metadata</code>, <code>receipt_email</code>, and <code>shipping</code> arguments.</p>",
         "operationId": "UpdateCharge",
         "parameters": [
           {
@@ -18673,6 +18714,10 @@
             "required": false,
             "schema": {
               "properties": {
+                "customer": {
+                  "description": "The ID of an existing customer that will be associated with this request. This field may only be updated if there is no existing associated customer with this charge.",
+                  "type": "string"
+                },
                 "description": {
                   "description": "An arbitrary string which you can attach to a charge object. It is displayed when in the web interface alongside the charge. Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing.",
                   "type": "string"
@@ -21692,7 +21737,7 @@
                   "type": "object"
                 },
                 "source": {
-                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                 },
                 "tax_percent": {
                   "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -21909,7 +21954,7 @@
                   "type": "integer"
                 },
                 "source": {
-                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                 },
                 "tax_percent": {
                   "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -25108,6 +25153,13 @@
             "type": "integer"
           },
           {
+            "description": "Only return plans for the given product.",
+            "in": "query",
+            "name": "product",
+            "required": false,
+            "type": "string"
+          },
+          {
             "description": "A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.",
             "in": "query",
             "name": "starting_after",
@@ -25222,8 +25274,26 @@
                   "type": "string"
                 },
                 "product": {
-                  "description": "The product whose pricing the created plan will represent.",
-                  "type": "string"
+                  "description": "The product whose pricing the created plan will represent. This can either be the ID of an existing product, or a dictionary containing fields used to create a [service product](/docs/api#product_object-type).",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "statement_descriptor": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "title": "inline_product_params",
+                  "type": "object"
                 },
                 "statement_descriptor": {
                   "description": "Displayed on customer statements when their card is charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor) page for an example.",
@@ -25369,6 +25439,10 @@
                   "description": "A brief description of the plan, hidden from customers.",
                   "type": "string"
                 },
+                "product": {
+                  "description": "The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected.",
+                  "type": "string"
+                },
                 "statement_descriptor": {
                   "description": "Displayed on customer statements when their card is charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor) page for an example.",
                   "type": "string"
@@ -25444,6 +25518,13 @@
             "description": "A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.",
             "in": "query",
             "name": "starting_after",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Only return products of this type.",
+            "in": "query",
+            "name": "type",
             "required": false,
             "type": "string"
           },
@@ -25596,6 +25677,18 @@
                 "shippable": {
                   "description": "Whether this product is shipped (i.e., physical goods). Defaults to `true`.",
                   "type": "boolean"
+                },
+                "statement_descriptor": {
+                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. The statement description may not include <>\"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all. May only be set if type=`service`.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "The type of the product. The product is either of type `good`, which is eligible for use with Orders and SKUs, or `service`, which is eligible for use with Subscriptions and Plans. Defaults to type `good`.",
+                  "enum": [
+                    "good",
+                    "service"
+                  ],
+                  "type": "string"
                 },
                 "url": {
                   "description": "A URL of a publicly-accessible webpage for this product.",
@@ -25784,6 +25877,10 @@
                 "shippable": {
                   "description": "Whether this product is shipped (i.e., physical goods). Defaults to `true`.",
                   "type": "boolean"
+                },
+                "statement_descriptor": {
+                  "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. The statement description may not include <>\"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all. May only be set if type=`service`.",
+                  "type": "string"
                 },
                 "url": {
                   "description": "A URL of a publicly-accessible webpage for this product.",
@@ -26428,7 +26525,7 @@
             "type": "integer"
           },
           {
-            "description": "The ID of the product whose SKUs will be retrieved.",
+            "description": "The ID of the product whose SKUs will be retrieved. Must be a product with type `good`.",
             "in": "query",
             "name": "product",
             "required": false,
@@ -26591,7 +26688,7 @@
                   "type": "integer"
                 },
                 "product": {
-                  "description": "The ID of the product this SKU is associated with.",
+                  "description": "The ID of the product this SKU is associated with. Must be a product with type `good`.",
                   "type": "string"
                 }
               },
@@ -26800,7 +26897,7 @@
                   "type": "integer"
                 },
                 "product": {
-                  "description": "The ID of the product that this SKU should belong to. The product must exist and have the same set of attribute names as the SKU's current product.",
+                  "description": "The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`.",
                   "type": "string"
                 }
               }
@@ -27045,6 +27142,53 @@
                   },
                   "type": "array"
                 },
+                "mandate": {
+                  "properties": {
+                    "acceptance": {
+                      "properties": {
+                        "date": {
+                          "type": "integer"
+                        },
+                        "ip": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "enum": [
+                            "accepted",
+                            "pending",
+                            "refused",
+                            "revoked"
+                          ],
+                          "type": "string"
+                        },
+                        "user_agent": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "date",
+                        "ip",
+                        "status",
+                        "user_agent"
+                      ],
+                      "title": "mandate_acceptance_params",
+                      "type": "object"
+                    },
+                    "notification_method": {
+                      "enum": [
+                        "email",
+                        "manual",
+                        "none"
+                      ],
+                      "type": "string"
+                    },
+                    "reference": {
+                      "type": "string"
+                    }
+                  },
+                  "title": "mandate_params",
+                  "type": "object"
+                },
                 "metadata": {
                   "description": "A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format.",
                   "type": "object"
@@ -27098,6 +27242,49 @@
             "description": "Successful response.",
             "schema": {
               "$ref": "#/definitions/source"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/sources/{source}/mandate_notifications/{mandate_notification}": {
+      "get": {
+        "description": "<p>Retrieves a new Source MandateNotification.</p>",
+        "operationId": "SourceMandateNotificationRetrieve",
+        "parameters": [
+          {
+            "description": "Specifies which fields in the response should be expanded.",
+            "in": "query",
+            "name": "expand",
+            "required": false,
+            "type": "array"
+          },
+          {
+            "description": "The ID of the Source MandateNotification.",
+            "in": "path",
+            "name": "mandate_notification",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "The ID of the Source that received a ManateNotification.",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "schema": {
+              "$ref": "#/definitions/source_mandate_notification"
             }
           },
           "default": {
@@ -27788,7 +27975,7 @@
                   "type": "object"
                 },
                 "source": {
-                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                 },
                 "tax_percent": {
                   "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -27990,7 +28177,7 @@
                   "type": "integer"
                 },
                 "source": {
-                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                  "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                 },
                 "tax_percent": {
                   "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",

--- a/openapi/spec2.yaml
+++ b/openapi/spec2.yaml
@@ -5,44 +5,45 @@ definitions:
   account:
     properties:
       business_name:
-        description: The publicly visible name of the business.
+        description: The publicly visible name of the business
         type: string
       business_url:
-        description: The publicly visible website of the business.
+        description: The publicly visible website of the business
         type: string
       charges_enabled:
-        description: Whether the account can create live charges.
+        description: Whether the account can create live charges
         type: boolean
       country:
-        description: The country of the account.
+        description: The country of the account
         type: string
       created:
         description: Time at which the object was created. Measured in seconds since
           the Unix epoch.
         type: integer
       debit_negative_balances:
-        description: Whether Stripe will attempt to reclaim negative account balances
-          from this account's bank account.
+        description: A Boolean indicating if Stripe should try to reclaim negative
+          balances from an attached bank account. See our [Understanding Connect Account
+          Balances](/docs/connect/account-balances) documentation for details.
         type: boolean
       decline_charge_on:
         "$ref": "#/definitions/account_decline_charge_on"
       default_currency:
-        description: The currency this account has chosen to use as the default.
+        description: The currency this account has chosen to use as the default
         type: string
       details_submitted:
-        description: Whether account details have been submitted yet. Standard accounts
-          cannot receive transfers before this is true.
+        description: Whether account details have been submitted. Standard accounts
+          cannot receive payouts before this is true.
         type: boolean
       display_name:
         description: The display name for this account. This is used on the Stripe
-          dashboard to help you differentiate between accounts.
+          Dashboard to differentiate between accounts.
         type: string
       email:
         description: The primary user's email address.
         type: string
       external_accounts:
-        description: External accounts (bank accounts and/or cards) currently attached
-          to this account.
+        description: External accounts (bank accounts and debit cards) currently attached
+          to this account
         properties:
           data:
             description: The list contains all external accounts that have been attached
@@ -91,40 +92,35 @@ definitions:
       payout_schedule:
         "$ref": "#/definitions/transfer_schedule"
       payout_statement_descriptor:
-        description: The text that will appear on the account's bank account statement
-          for payouts. If not set, this will default to your platform's bank descriptor
-          set on the Dashboard.
+        description: The text that appears on the bank account statement for payouts.
+          If not set, this defaults to the platform's bank descriptor as set in the
+          Dashboard.
         type: string
       payouts_enabled:
-        description: Whether Stripe will send automatic transfers for this account.
-          This is only false when Stripe is waiting for additional information from
-          the account holder.
+        description: Whether Stripe can send payouts to this account
         type: boolean
       product_description:
-        description: An internal-only description of the product or service provided.
-          This is used by Stripe in the event the account gets flagged for potential
-          fraud.
+        description: Internal-only description of the product sold or service provided
+          by the business. It's used by Stripe for risk and underwriting purposes.
         type: string
       statement_descriptor:
-        description: The text that will appear on credit card statements.
+        description: The default text that appears on credit card statements when
+          a charge is made [directly on the account](/docs/connect/direct-charges)
         type: string
       support_email:
-        description: A publicly shareable email address that can be reached for support
-          for this account.
+        description: A publicly shareable support email address for the business
         type: string
       support_phone:
-        description: The publicly visible support phone number for the business.
+        description: A publicly shareable support phone number for the business
         type: string
       timezone:
-        description: The time zone used in the Stripe dashboard for this account.
-          A list of possible time zone values is maintained at the [IANA Time Zone
-          Database](http://www.iana.org/time-zones).
+        description: The timezone used in the Stripe Dashboard for this account. A
+          list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).
         type: string
       tos_acceptance:
         "$ref": "#/definitions/account_tos_acceptance"
       type:
-        description: The type of the Stripe account. Can be `standard`, `express`,
-          or `custom`.
+        description: The Stripe account type. Can be `standard`, `express`, or `custom`.
         type: string
       verification:
         "$ref": "#/definitions/account_verification"
@@ -169,12 +165,12 @@ definitions:
     properties:
       avs_failure:
         description: Whether Stripe should automatically decline charges with an incorrect
-          ZIP or postal code. This setting only applies if a card includes a ZIP or
-          postal code and the bank specifically marks it as failed.
+          ZIP or postal code. This setting only applies when a ZIP or postal code
+          is provided and the bank specifically marks it as failed.
         type: boolean
       cvc_failure:
         description: Whether Stripe should automatically decline charges with an incorrect
-          CVC. This setting only applies if a card includes a CVC and the bank specifically
+          CVC. This setting only applies when a CVC is provided and the bank specifically
           marks it as failed.
         type: boolean
     required:
@@ -186,15 +182,16 @@ definitions:
   account_tos_acceptance:
     properties:
       date:
-        description: The timestamp when the account owner accepted Stripe's terms.
+        description: The Unix timestamp marking when the Stripe Services Agreement
+          was accepted by the account representative
         type: integer
       ip:
-        description: The IP address from which the account owner accepted Stripe's
-          terms.
+        description: The IP address from which the Stripe Services Agreement was accepted
+          by the account representative
         type: string
       user_agent:
-        description: The user agent of the browser from which the user accepted Stripe's
-          terms.
+        description: The user agent of the browser from which the Stripe Services
+          Agreement was accepted by the account representative
         type: string
     title: AccountTOSAcceptance
     type: object
@@ -203,20 +200,20 @@ definitions:
     properties:
       disabled_reason:
         description: A string describing the reason for this account being unable
-          to charge and/or transfer, if that is the case. Possible values are `rejected.fraud`,
+          to create charges or receive payouts, if that is the case. Can be `rejected.fraud`,
           `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`,
           `listed`, `under_review`, or `other`.
         type: string
       due_by:
-        description: At what time the `fields_needed` must be provided. If this date
+        description: By what time the `fields_needed` must be provided. If this date
           is in the past, the account is already in bad standing, and providing `fields_needed`
-          is necessary to re-enable transfers and prevent other consequences. If this
+          is necessary to re-enable payouts and prevent other consequences. If this
           date is in the future, `fields_needed` must be provided to ensure the account
           remains in good standing.
         type: integer
       fields_needed:
         description: Field names that need to be provided for the account to remain
-          in good standing. Nested fields are separated by "." (for example, "legal_entity.first_name").
+          in good standing. Nested fields are separated by `.` (for example, `legal_entity.first_name`).
         type: array
     required:
     - fields_needed
@@ -226,44 +223,45 @@ definitions:
   account_with_keys:
     properties:
       business_name:
-        description: The publicly visible name of the business.
+        description: The publicly visible name of the business
         type: string
       business_url:
-        description: The publicly visible website of the business.
+        description: The publicly visible website of the business
         type: string
       charges_enabled:
-        description: Whether the account can create live charges.
+        description: Whether the account can create live charges
         type: boolean
       country:
-        description: The country of the account.
+        description: The country of the account
         type: string
       created:
         description: Time at which the object was created. Measured in seconds since
           the Unix epoch.
         type: integer
       debit_negative_balances:
-        description: Whether Stripe will attempt to reclaim negative account balances
-          from this account's bank account.
+        description: A Boolean indicating if Stripe should try to reclaim negative
+          balances from an attached bank account. See our [Understanding Connect Account
+          Balances](/docs/connect/account-balances) documentation for details.
         type: boolean
       decline_charge_on:
         "$ref": "#/definitions/account_decline_charge_on"
       default_currency:
-        description: The currency this account has chosen to use as the default.
+        description: The currency this account has chosen to use as the default
         type: string
       details_submitted:
-        description: Whether account details have been submitted yet. Standard accounts
-          cannot receive transfers before this is true.
+        description: Whether account details have been submitted. Standard accounts
+          cannot receive payouts before this is true.
         type: boolean
       display_name:
         description: The display name for this account. This is used on the Stripe
-          dashboard to help you differentiate between accounts.
+          Dashboard to differentiate between accounts.
         type: string
       email:
         description: The primary user's email address.
         type: string
       external_accounts:
-        description: External accounts (bank accounts and/or cards) currently attached
-          to this account.
+        description: External accounts (bank accounts and debit cards) currently attached
+          to this account
         properties:
           data:
             description: The list contains all external accounts that have been attached
@@ -314,40 +312,35 @@ definitions:
       payout_schedule:
         "$ref": "#/definitions/transfer_schedule"
       payout_statement_descriptor:
-        description: The text that will appear on the account's bank account statement
-          for payouts. If not set, this will default to your platform's bank descriptor
-          set on the Dashboard.
+        description: The text that appears on the bank account statement for payouts.
+          If not set, this defaults to the platform's bank descriptor as set in the
+          Dashboard.
         type: string
       payouts_enabled:
-        description: Whether Stripe will send automatic transfers for this account.
-          This is only false when Stripe is waiting for additional information from
-          the account holder.
+        description: Whether Stripe can send payouts to this account
         type: boolean
       product_description:
-        description: An internal-only description of the product or service provided.
-          This is used by Stripe in the event the account gets flagged for potential
-          fraud.
+        description: Internal-only description of the product sold or service provided
+          by the business. It's used by Stripe for risk and underwriting purposes.
         type: string
       statement_descriptor:
-        description: The text that will appear on credit card statements.
+        description: The default text that appears on credit card statements when
+          a charge is made [directly on the account](/docs/connect/direct-charges)
         type: string
       support_email:
-        description: A publicly shareable email address that can be reached for support
-          for this account.
+        description: A publicly shareable support email address for the business
         type: string
       support_phone:
-        description: The publicly visible support phone number for the business.
+        description: A publicly shareable support phone number for the business
         type: string
       timezone:
-        description: The time zone used in the Stripe dashboard for this account.
-          A list of possible time zone values is maintained at the [IANA Time Zone
-          Database](http://www.iana.org/time-zones).
+        description: The timezone used in the Stripe Dashboard for this account. A
+          list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).
         type: string
       tos_acceptance:
         "$ref": "#/definitions/account_tos_acceptance"
       type:
-        description: The type of the Stripe account. Can be `standard`, `express`,
-          or `custom`.
+        description: The Stripe account type. Can be `standard`, `express`, or `custom`.
         type: string
       verification:
         "$ref": "#/definitions/account_verification"
@@ -3725,8 +3718,8 @@ definitions:
           be useful for storing additional information about the object in a structured
           format.
         type: object
-      name:
-        description: Display name of the plan.
+      nickname:
+        description: A brief description of the plan, hidden from customers.
         type: string
       object:
         description: String representing the object's type. Objects of the same type
@@ -3734,8 +3727,8 @@ definitions:
         enum:
         - plan
         type: string
-      statement_descriptor:
-        description: Displayed on customer statements when their card is charged.
+      product:
+        description: The product whose pricing this plan determines.
         type: string
     required:
     - created
@@ -3745,7 +3738,6 @@ definitions:
     - interval_count
     - livemode
     - metadata
-    - name
     - object
     title: Plan
     type: object
@@ -4075,6 +4067,17 @@ definitions:
         type: object
         x-expandableFields:
         - data
+      statement_descriptor:
+        description: Extra information about a product which will appear on your customer's
+          credit card statement. In the case that multiple products are billed at
+          once, the first statement descriptor will be used. Only available on products
+          of type=`service`.
+        type: string
+      type:
+        description: The type of the product. The product is either of type `good`,
+          which is eligible for use with Orders and SKUs, or `service`, which is eligible
+          for use with Subscriptions and Plans.
+        type: string
       updated:
         type: integer
       url:
@@ -4658,6 +4661,55 @@ definitions:
     title: SourceCodeVerificationFlow
     type: object
     x-expandableFields: []
+  source_mandate_notification:
+    properties:
+      amount:
+        description: Amount associated with the mandate notification. The amount is
+          expressed in the currency of the underlying Source. Set if the notification
+          type is `debit_initiated`.
+        type: integer
+      created:
+        description: Time at which the object was created. Measured in seconds since
+          the Unix epoch.
+        type: integer
+      id:
+        description: Unique identifier for the object.
+        type: string
+      livemode:
+        description: Flag indicating whether the object exists in live mode or test
+          mode.
+        type: boolean
+      object:
+        description: String representing the object's type. Objects of the same type
+          share the same value.
+        enum:
+        - source_mandate_notification
+        type: string
+      reason:
+        description: The reason of the mandate notification.
+        type: string
+      source:
+        "$ref": "#/definitions/source"
+      status:
+        description: The status of the mandate notification.
+        type: string
+      type:
+        description: The type of source this mandate notification is attached to.
+        type: string
+    required:
+    - created
+    - id
+    - livemode
+    - object
+    - reason
+    - source
+    - status
+    - type
+    title: SourceMandateNotification
+    type: object
+    x-expandableFields:
+    - source
+    x-resourceId: source_mandate_notification
   source_owner:
     properties:
       address:
@@ -6161,7 +6213,7 @@ info:
     details.
   termsOfService: https://stripe.com/us/terms/
   title: Stripe API
-  version: '2017-12-14'
+  version: '2018-01-15'
 paths:
   "/v1/3d_secure":
     post:
@@ -6277,8 +6329,8 @@ paths:
         name: expand
         required: false
         type: array
-      - description: The identifier of the account to be retrieved. If none is provided,
-          will default to the account of the API key.
+      - description: The identifier of the account to retrieve. If none is provided,
+          the account associated with the API key is returned.
         in: query
         name: account
         required: false
@@ -6318,21 +6370,21 @@ paths:
               type: string
             business_primary_color:
               description: A CSS hex color value representing the primary branding
-                color for this account.
+                color for this account
               type: string
             business_url:
               description: The URL that best shows the service or product provided
-                for this account.
+                by this account
               type: string
             debit_negative_balances:
-              description: A Boolean for whether Stripe should try to reclaim negative
-                balances from the account holder's bank account. See our [Connect
-                account bank transfer guide](/docs/connect/account-balances) for more
-                information.
+              description: A Boolean indicating if Stripe should try to reclaim negative
+                balances from an attached bank account. See our [Understanding Connect
+                Account Balances](/docs/connect/account-balances) documentation for
+                details.
               type: boolean
             decline_charge_on:
               description: Account-level settings to automatically decline certain
-                types of charges regardless of the bank's decision.
+                types of charges regardless of the decision of the card issuer.
               properties:
                 avs_failure:
                   type: boolean
@@ -6346,10 +6398,10 @@ paths:
                 in the account's country](https://stripe.com/docs/payouts).
               type: string
             email:
-              description: 'Email address of the account holder. For Standard accounts,
-                this is used to email them asking them to claim their Stripe account.
-                For Custom accounts, this is only to make the account easier to identify
-                to you: Stripe will not email the account holder.'
+              description: Email address of the account representative. For Standard
+                accounts, this is used to ask them to claim their Stripe account.
+                For Custom accounts, this only makes the account easier to identify
+                to platforms; Stripe does not email the account representative.
               type: string
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -6361,14 +6413,14 @@ paths:
                 provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                 or a dictionary as documented in the `external_account` parameter
                 for [bank account](/docs/api#account_create_bank_account) creation.
-                <br><br>This will create a new external account object, make it the
-                new default external account for its currency, and delete the old
-                default if one exists. If you want to add additional external accounts
-                instead of replacing the existing default for this currency, use the
-                bank account or card creation API.
+                <br><br>By default, providing an external account sets it as the new
+                default external account for its currency and deletes the old default
+                if one exists. To add additional external accounts without replacing
+                the existing default for the currency, use the bank account or card
+                creation API.
             legal_entity:
-              description: Information about the account holder; varies by [account
-                country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).
+              description: Information about the legal entity itself, including about
+                the associated account representative
               properties:
                 additional_owners:
                   properties:
@@ -8025,15 +8077,15 @@ paths:
               title: account_legal_entity_specs
               type: object
             metadata:
-              description: A set of key/value pairs that you can attach to an account
+              description: A set of key-value pairs that you can attach to an `Account`
                 object. It can be useful for storing additional information about
                 the account in a structured format.
               type: object
             payout_schedule:
-              description: Details on when this account will make funds from charges
-                available, and when they will be paid out to the account holder's
-                bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                for more information.
+              description: Details on when funds from charges are available, and when
+                they are paid out to an external account. See our [Setting Bank and
+                Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                documentation for details.
               properties:
                 delay_days:
                   type: integer
@@ -8060,45 +8112,31 @@ paths:
               title: transfer_schedule_specs
               type: object
             payout_statement_descriptor:
-              description: The text that will appear on the account's bank account
-                statement for payouts. If not set, this will default to your platform's
-                bank descriptor set on the Dashboard.
+              description: The text that appears on the bank account statement for
+                payouts. If not set, this defaults to the platform's bank descriptor
+                as set in the Dashboard.
               type: string
             product_description:
-              description: Internal-only description of the product being sold or
-                service being provided by this account. It's used by Stripe for risk
-                and underwriting purposes.
+              description: Internal-only description of the product sold or service
+                provided by the business. It's used by Stripe for risk and underwriting
+                purposes.
               type: string
             statement_descriptor:
-              description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-              type: string
-            statement_descriptor_kana:
-              description: The Kana variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
-              type: string
-            statement_descriptor_kanji:
-              description: The Kanji variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
+              description: The default text that appears on credit card statements
+                when a charge is made [directly on the account](/docs/connect/direct-charges)
               type: string
             support_email:
-              description: A publicly shareable email address that can be reached
-                for support for this account.
+              description: A publicly shareable support email address for the business
               type: string
             support_phone:
-              description: A publicly shareable phone number that can be reached for
-                support for this account.
+              description: A publicly shareable support phone number for the business
               type: string
             support_url:
-              description: A publicly shareable URL that can be reached for support
-                for this account.
+              description: A publicly shareable URL that provides support for this
+                account
               type: string
             tos_acceptance:
-              description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                for more information.
+              description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
               properties:
                 date:
                   type: integer
@@ -8132,9 +8170,9 @@ paths:
         schema:
           properties:
             default_for_currency:
-              description: If you set this to true (or if this is the first external
-                account being added in this currency) this account will become the
-                default external account for its currency.
+              description: When set to true, or if this is the first external account
+                added in this currency, this account becomes the default external
+                account for its currency.
               type: boolean
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -8144,7 +8182,7 @@ paths:
             external_account:
               description: This string to be replaced by DocSpecGenerator.
             metadata:
-              description: A set of key/value pairs that you can attach to an external
+              description: A set of key-value pairs that you can attach to an external
                 account object. It can be useful for storing additional information
                 about the external account in a structured format.
               type: object
@@ -8219,7 +8257,7 @@ paths:
         or changes.</p>
       operationId: UpdateAccountExternalAccount
       parameters:
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -8357,9 +8395,9 @@ paths:
         schema:
           properties:
             default_for_currency:
-              description: If you set this to true (or if this is the first external
-                account being added in this currency) this account will become the
-                default external account for its currency.
+              description: When set to true, or if this is the first external account
+                added in this currency, this account becomes the default external
+                account for its currency.
               type: boolean
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -8369,7 +8407,7 @@ paths:
             external_account:
               description: This string to be replaced by DocSpecGenerator.
             metadata:
-              description: A set of key/value pairs that you can attach to an external
+              description: A set of key-value pairs that you can attach to an external
                 account object. It can be useful for storing additional information
                 about the external account in a structured format.
               type: object
@@ -8444,7 +8482,7 @@ paths:
         or changes.</p>
       operationId: UpdateAccountExternalAccount
       parameters:
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -8572,8 +8610,7 @@ paths:
   "/v1/accounts":
     get:
       description: <p>Returns a list of accounts connected to your platform via <a
-        href="/docs/connect">Connect</a>. If you’re not a platform, the list will
-        be empty.</p>
+        href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.</p>
       operationId: AllAccount
       parameters:
       - description: Specifies which fields in the response should be expanded.
@@ -8660,23 +8697,23 @@ paths:
               type: string
             business_primary_color:
               description: A CSS hex color value representing the primary branding
-                color for this account.
+                color for this account
               type: string
             business_url:
               description: The URL that best shows the service or product provided
-                for this account.
+                by this account
               type: string
             country:
               type: string
             debit_negative_balances:
-              description: A Boolean for whether Stripe should try to reclaim negative
-                balances from the account holder's bank account. See our [Connect
-                account bank transfer guide](/docs/connect/account-balances) for more
-                information.
+              description: A Boolean indicating if Stripe should try to reclaim negative
+                balances from an attached bank account. See our [Understanding Connect
+                Account Balances](/docs/connect/account-balances) documentation for
+                details.
               type: boolean
             decline_charge_on:
               description: Account-level settings to automatically decline certain
-                types of charges regardless of the bank's decision.
+                types of charges regardless of the decision of the card issuer.
               properties:
                 avs_failure:
                   type: boolean
@@ -8692,10 +8729,10 @@ paths:
             display_name:
               type: string
             email:
-              description: 'Email address of the account holder. For Standard accounts,
-                this is used to email them asking them to claim their Stripe account.
-                For Custom accounts, this is only to make the account easier to identify
-                to you: Stripe will not email the account holder.'
+              description: Email address of the account representative. For Standard
+                accounts, this is used to ask them to claim their Stripe account.
+                For Custom accounts, this only makes the account easier to identify
+                to platforms; Stripe does not email the account representative.
               type: string
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -8707,16 +8744,16 @@ paths:
                 provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                 or a dictionary as documented in the `external_account` parameter
                 for [bank account](/docs/api#account_create_bank_account) creation.
-                <br><br>This will create a new external account object, make it the
-                new default external account for its currency, and delete the old
-                default if one exists. If you want to add additional external accounts
-                instead of replacing the existing default for this currency, use the
-                bank account or card creation API.
+                <br><br>By default, providing an external account sets it as the new
+                default external account for its currency and deletes the old default
+                if one exists. To add additional external accounts without replacing
+                the existing default for the currency, use the bank account or card
+                creation API.
             from_recipient:
               type: string
             legal_entity:
-              description: Information about the account holder; varies by [account
-                country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).
+              description: Information about the legal entity itself, including about
+                the associated account representative
               properties:
                 additional_owners:
                   properties:
@@ -10375,15 +10412,15 @@ paths:
             make_ready_for_panda:
               type: boolean
             metadata:
-              description: A set of key/value pairs that you can attach to an account
+              description: A set of key-value pairs that you can attach to an `Account`
                 object. It can be useful for storing additional information about
                 the account in a structured format.
               type: object
             payout_schedule:
-              description: Details on when this account will make funds from charges
-                available, and when they will be paid out to the account holder's
-                bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                for more information.
+              description: Details on when funds from charges are available, and when
+                they are paid out to an external account. See our [Setting Bank and
+                Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                documentation for details.
               properties:
                 delay_days:
                   type: integer
@@ -10410,47 +10447,33 @@ paths:
               title: transfer_schedule_specs
               type: object
             payout_statement_descriptor:
-              description: The text that will appear on the account's bank account
-                statement for payouts. If not set, this will default to your platform's
-                bank descriptor set on the Dashboard.
+              description: The text that appears on the bank account statement for
+                payouts. If not set, this defaults to the platform's bank descriptor
+                as set in the Dashboard.
               type: string
             primary_user:
               type: string
             product_description:
-              description: Internal-only description of the product being sold or
-                service being provided by this account. It's used by Stripe for risk
-                and underwriting purposes.
+              description: Internal-only description of the product sold or service
+                provided by the business. It's used by Stripe for risk and underwriting
+                purposes.
               type: string
             statement_descriptor:
-              description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-              type: string
-            statement_descriptor_kana:
-              description: The Kana variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
-              type: string
-            statement_descriptor_kanji:
-              description: The Kanji variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
+              description: The default text that appears on credit card statements
+                when a charge is made [directly on the account](/docs/connect/direct-charges)
               type: string
             support_email:
-              description: A publicly shareable email address that can be reached
-                for support for this account.
+              description: A publicly shareable support email address for the business
               type: string
             support_phone:
-              description: A publicly shareable phone number that can be reached for
-                support for this account.
+              description: A publicly shareable support phone number for the business
               type: string
             support_url:
-              description: A publicly shareable URL that can be reached for support
-                for this account.
+              description: A publicly shareable URL that provides support for this
+                account
               type: string
             tos_acceptance:
-              description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                for more information.
+              description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
               properties:
                 date:
                   type: integer
@@ -10523,8 +10546,8 @@ paths:
         name: expand
         required: false
         type: array
-      - description: The identifier of the account to be retrieved. If none is provided,
-          will default to the account of the API key.
+      - description: The identifier of the account to retrieve. If none is provided,
+          the account associated with the API key is returned.
         in: path
         name: account
         required: true
@@ -10566,21 +10589,21 @@ paths:
               type: string
             business_primary_color:
               description: A CSS hex color value representing the primary branding
-                color for this account.
+                color for this account
               type: string
             business_url:
               description: The URL that best shows the service or product provided
-                for this account.
+                by this account
               type: string
             debit_negative_balances:
-              description: A Boolean for whether Stripe should try to reclaim negative
-                balances from the account holder's bank account. See our [Connect
-                account bank transfer guide](/docs/connect/account-balances) for more
-                information.
+              description: A Boolean indicating if Stripe should try to reclaim negative
+                balances from an attached bank account. See our [Understanding Connect
+                Account Balances](/docs/connect/account-balances) documentation for
+                details.
               type: boolean
             decline_charge_on:
               description: Account-level settings to automatically decline certain
-                types of charges regardless of the bank's decision.
+                types of charges regardless of the decision of the card issuer.
               properties:
                 avs_failure:
                   type: boolean
@@ -10594,10 +10617,10 @@ paths:
                 in the account's country](https://stripe.com/docs/payouts).
               type: string
             email:
-              description: 'Email address of the account holder. For Standard accounts,
-                this is used to email them asking them to claim their Stripe account.
-                For Custom accounts, this is only to make the account easier to identify
-                to you: Stripe will not email the account holder.'
+              description: Email address of the account representative. For Standard
+                accounts, this is used to ask them to claim their Stripe account.
+                For Custom accounts, this only makes the account easier to identify
+                to platforms; Stripe does not email the account representative.
               type: string
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -10609,14 +10632,14 @@ paths:
                 provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                 or a dictionary as documented in the `external_account` parameter
                 for [bank account](/docs/api#account_create_bank_account) creation.
-                <br><br>This will create a new external account object, make it the
-                new default external account for its currency, and delete the old
-                default if one exists. If you want to add additional external accounts
-                instead of replacing the existing default for this currency, use the
-                bank account or card creation API.
+                <br><br>By default, providing an external account sets it as the new
+                default external account for its currency and deletes the old default
+                if one exists. To add additional external accounts without replacing
+                the existing default for the currency, use the bank account or card
+                creation API.
             legal_entity:
-              description: Information about the account holder; varies by [account
-                country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).
+              description: Information about the legal entity itself, including about
+                the associated account representative
               properties:
                 additional_owners:
                   properties:
@@ -12273,15 +12296,15 @@ paths:
               title: account_legal_entity_specs
               type: object
             metadata:
-              description: A set of key/value pairs that you can attach to an account
+              description: A set of key-value pairs that you can attach to an `Account`
                 object. It can be useful for storing additional information about
                 the account in a structured format.
               type: object
             payout_schedule:
-              description: Details on when this account will make funds from charges
-                available, and when they will be paid out to the account holder's
-                bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                for more information.
+              description: Details on when funds from charges are available, and when
+                they are paid out to an external account. See our [Setting Bank and
+                Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                documentation for details.
               properties:
                 delay_days:
                   type: integer
@@ -12308,45 +12331,31 @@ paths:
               title: transfer_schedule_specs
               type: object
             payout_statement_descriptor:
-              description: The text that will appear on the account's bank account
-                statement for payouts. If not set, this will default to your platform's
-                bank descriptor set on the Dashboard.
+              description: The text that appears on the bank account statement for
+                payouts. If not set, this defaults to the platform's bank descriptor
+                as set in the Dashboard.
               type: string
             product_description:
-              description: Internal-only description of the product being sold or
-                service being provided by this account. It's used by Stripe for risk
-                and underwriting purposes.
+              description: Internal-only description of the product sold or service
+                provided by the business. It's used by Stripe for risk and underwriting
+                purposes.
               type: string
             statement_descriptor:
-              description: The text that will appear on credit card statements by
-                default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-              type: string
-            statement_descriptor_kana:
-              description: The Kana variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
-              type: string
-            statement_descriptor_kanji:
-              description: The Kanji variation of the text that will appear on credit
-                card statements by default if a charge is being made [directly on
-                the account](/docs/connect/direct-charges) (Japan only).
+              description: The default text that appears on credit card statements
+                when a charge is made [directly on the account](/docs/connect/direct-charges)
               type: string
             support_email:
-              description: A publicly shareable email address that can be reached
-                for support for this account.
+              description: A publicly shareable support email address for the business
               type: string
             support_phone:
-              description: A publicly shareable phone number that can be reached for
-                support for this account.
+              description: A publicly shareable support phone number for the business
               type: string
             support_url:
-              description: A publicly shareable URL that can be reached for support
-                for this account.
+              description: A publicly shareable URL that provides support for this
+                account
               type: string
             tos_acceptance:
-              description: Details on who accepted the Stripe terms of service, and
-                when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                for more information.
+              description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
               properties:
                 date:
                   type: integer
@@ -12384,9 +12393,9 @@ paths:
         schema:
           properties:
             default_for_currency:
-              description: If you set this to true (or if this is the first external
-                account being added in this currency) this account will become the
-                default external account for its currency.
+              description: When set to true, or if this is the first external account
+                added in this currency, this account becomes the default external
+                account for its currency.
               type: boolean
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -12396,7 +12405,7 @@ paths:
             external_account:
               description: This string to be replaced by DocSpecGenerator.
             metadata:
-              description: A set of key/value pairs that you can attach to an external
+              description: A set of key-value pairs that you can attach to an external
                 account object. It can be useful for storing additional information
                 about the external account in a structured format.
               type: object
@@ -12483,7 +12492,7 @@ paths:
         name: account
         required: true
         type: string
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -12629,9 +12638,9 @@ paths:
         schema:
           properties:
             default_for_currency:
-              description: If you set this to true (or if this is the first external
-                account being added in this currency) this account will become the
-                default external account for its currency.
+              description: When set to true, or if this is the first external account
+                added in this currency, this account becomes the default external
+                account for its currency.
               type: boolean
             expand:
               description: Specifies which fields in the response should be expanded.
@@ -12641,7 +12650,7 @@ paths:
             external_account:
               description: This string to be replaced by DocSpecGenerator.
             metadata:
-              description: A set of key/value pairs that you can attach to an external
+              description: A set of key-value pairs that you can attach to an external
                 account object. It can be useful for storing additional information
                 about the external account in a structured format.
               type: object
@@ -12728,7 +12737,7 @@ paths:
         name: account
         required: true
         type: string
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -12861,7 +12870,7 @@ paths:
         all balances are zero.</p>
       operationId: AccountReject
       parameters:
-      - description: The identifier of the account to be rejected.
+      - description: The identifier of the account to reject
         in: path
         name: account
         required: true
@@ -12878,8 +12887,8 @@ paths:
                 type: string
               type: array
             reason:
-              description: The reason for rejecting the account. May be one of `fraud`,
-                `terms_of_service`, or `other`.
+              description: The reason for rejecting the account. Can be `fraud`, `terms_of_service`,
+                or `other`.
               type: string
           required:
           - reason
@@ -14116,8 +14125,9 @@ paths:
     post:
       description: "<p>Updates the specified charge by setting the values of the parameters
         passed. Any parameters not provided will be left unchanged.</p><p>This request
-        accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>,
-        <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>"
+        accepts only the <code>customer</code>, <code>description</code>, <code>fraud_details</code>,
+        <code>metadata</code>, <code>receipt_email</code>, and <code>shipping</code>
+        arguments.</p>"
       operationId: UpdateCharge
       parameters:
       - in: path
@@ -14130,6 +14140,11 @@ paths:
         required: false
         schema:
           properties:
+            customer:
+              description: The ID of an existing customer that will be associated
+                with this request. This field may only be updated if there is no existing
+                associated customer with this charge.
+              type: string
             description:
               description: An arbitrary string which you can attach to a charge object.
                 It is displayed when in the web interface alongside the charge. Note
@@ -16440,9 +16455,9 @@ paths:
                 default source, and delete the old customer default if one exists.
                 If you want to add an additional source, instead use the [card creation
                 API](https://stripe.com/docs/api#create_card) to add the card and
-                then the [customer update API](https://stripe.com/docs/api#update
-                customer) to set it as the default. Whenever you attach a card to
-                a customer, Stripe will automatically validate the card.
+                then the [customer update API](https://stripe.com/docs/api#update_customer)
+                to set it as the default. Whenever you attach a card to a customer,
+                Stripe will automatically validate the card.
             tax_percent:
               description: A non-negative decimal (with at most four decimal places)
                 between 0 and 100. This represents the percentage of the subscription
@@ -16646,9 +16661,9 @@ paths:
                 default source, and delete the old customer default if one exists.
                 If you want to add an additional source, instead use the [card creation
                 API](https://stripe.com/docs/api#create_card) to add the card and
-                then the [customer update API](https://stripe.com/docs/api#update
-                customer) to set it as the default. Whenever you attach a card to
-                a customer, Stripe will automatically validate the card.
+                then the [customer update API](https://stripe.com/docs/api#update_customer)
+                to set it as the default. Whenever you attach a card to a customer,
+                Stripe will automatically validate the card.
             tax_percent:
               description: A non-negative decimal (with at most four decimal places)
                 between 0 and 100. This represents the percentage of the subscription
@@ -19198,6 +19213,11 @@ paths:
         name: limit
         required: false
         type: integer
+      - description: Only return plans for the given product.
+        in: query
+        name: product
+        required: false
+        type: string
       - description: A cursor for use in pagination. `starting_after` is an object
           ID that defines your place in the list. For instance, if you make a list
           request and receive 100 objects, ending with `obj_foo`, your subsequent
@@ -19301,7 +19321,21 @@ paths:
               type: string
             product:
               description: The product whose pricing the created plan will represent.
-              type: string
+                This can either be the ID of an existing product, or a dictionary
+                containing fields used to create a [service product](/docs/api#product_object-type).
+              properties:
+                id:
+                  type: string
+                metadata:
+                  type: object
+                name:
+                  type: string
+                statement_descriptor:
+                  type: string
+              required:
+              - name
+              title: inline_product_params
+              type: object
             statement_descriptor:
               description: Displayed on customer statements when their card is charged.
                 See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor)
@@ -19408,6 +19442,11 @@ paths:
             nickname:
               description: A brief description of the plan, hidden from customers.
               type: string
+            product:
+              description: The product the plan belongs to. Note that after updating,
+                statement descriptors and line items of the plan in active subscriptions
+                will be affected.
+              type: string
             statement_descriptor:
               description: Displayed on customer statements when their card is charged.
                 See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor)
@@ -19473,6 +19512,11 @@ paths:
           of the list.
         in: query
         name: starting_after
+        required: false
+        type: string
+      - description: Only return products of this type.
+        in: query
+        name: type
         required: false
         type: string
       - description: Only return products with the given url.
@@ -19597,6 +19641,24 @@ paths:
               description: Whether this product is shipped (i.e., physical goods).
                 Defaults to `true`.
               type: boolean
+            statement_descriptor:
+              description: An arbitrary string to be displayed on your customer's
+                credit card statement. This may be up to 22 characters. The statement
+                description may not include <>"' characters, and will appear on your
+                customer's statement in capital letters. Non-ASCII characters are
+                automatically stripped. While most banks display this information
+                consistently, some may display it incorrectly or not at all. May only
+                be set if type=`service`.
+              type: string
+            type:
+              description: The type of the product. The product is either of type
+                `good`, which is eligible for use with Orders and SKUs, or `service`,
+                which is eligible for use with Subscriptions and Plans. Defaults to
+                type `good`.
+              enum:
+              - good
+              - service
+              type: string
             url:
               description: A URL of a publicly-accessible webpage for this product.
               type: string
@@ -19745,6 +19807,15 @@ paths:
               description: Whether this product is shipped (i.e., physical goods).
                 Defaults to `true`.
               type: boolean
+            statement_descriptor:
+              description: An arbitrary string to be displayed on your customer's
+                credit card statement. This may be up to 22 characters. The statement
+                description may not include <>"' characters, and will appear on your
+                customer's statement in capital letters. Non-ASCII characters are
+                automatically stripped. While most banks display this information
+                consistently, some may display it incorrectly or not at all. May only
+                be set if type=`service`.
+              type: string
             url:
               description: A URL of a publicly-accessible webpage for this product.
               type: string
@@ -20222,7 +20293,8 @@ paths:
         name: limit
         required: false
         type: integer
-      - description: The ID of the product whose SKUs will be retrieved.
+      - description: The ID of the product whose SKUs will be retrieved. Must be a
+          product with type `good`.
         in: query
         name: product
         required: false
@@ -20357,7 +20429,8 @@ paths:
                 ¥100, Japanese Yen being a zero-decimal currency).
               type: integer
             product:
-              description: The ID of the product this SKU is associated with.
+              description: The ID of the product this SKU is associated with. Must
+                be a product with type `good`.
               type: string
           required:
           - currency
@@ -20521,8 +20594,8 @@ paths:
               type: integer
             product:
               description: The ID of the product that this SKU should belong to. The
-                product must exist and have the same set of attribute names as the
-                SKU's current product.
+                product must exist, have the same set of attribute names as the SKU's
+                current product, and be of type `good`.
               type: string
       responses:
         '200':
@@ -20718,6 +20791,40 @@ paths:
               items:
                 type: string
               type: array
+            mandate:
+              properties:
+                acceptance:
+                  properties:
+                    date:
+                      type: integer
+                    ip:
+                      type: string
+                    status:
+                      enum:
+                      - accepted
+                      - pending
+                      - refused
+                      - revoked
+                      type: string
+                    user_agent:
+                      type: string
+                  required:
+                  - date
+                  - ip
+                  - status
+                  - user_agent
+                  title: mandate_acceptance_params
+                  type: object
+                notification_method:
+                  enum:
+                  - email
+                  - manual
+                  - none
+                  type: string
+                reference:
+                  type: string
+              title: mandate_params
+              type: object
             metadata:
               description: A set of key/value pairs that you can attach to a source
                 object. It can be useful for storing additional information about
@@ -20756,6 +20863,35 @@ paths:
           description: Successful response.
           schema:
             "$ref": "#/definitions/source"
+        default:
+          description: Error response.
+          schema:
+            "$ref": "#/definitions/error"
+  "/v1/sources/{source}/mandate_notifications/{mandate_notification}":
+    get:
+      description: "<p>Retrieves a new Source MandateNotification.</p>"
+      operationId: SourceMandateNotificationRetrieve
+      parameters:
+      - description: Specifies which fields in the response should be expanded.
+        in: query
+        name: expand
+        required: false
+        type: array
+      - description: The ID of the Source MandateNotification.
+        in: path
+        name: mandate_notification
+        required: true
+        type: string
+      - description: The ID of the Source that received a ManateNotification.
+        in: path
+        name: source
+        required: true
+        type: string
+      responses:
+        '200':
+          description: Successful response.
+          schema:
+            "$ref": "#/definitions/source_mandate_notification"
         default:
           description: Error response.
           schema:
@@ -21317,9 +21453,9 @@ paths:
                 default source, and delete the old customer default if one exists.
                 If you want to add an additional source, instead use the [card creation
                 API](https://stripe.com/docs/api#create_card) to add the card and
-                then the [customer update API](https://stripe.com/docs/api#update
-                customer) to set it as the default. Whenever you attach a card to
-                a customer, Stripe will automatically validate the card.
+                then the [customer update API](https://stripe.com/docs/api#update_customer)
+                to set it as the default. Whenever you attach a card to a customer,
+                Stripe will automatically validate the card.
             tax_percent:
               description: A non-negative decimal (with at most four decimal places)
                 between 0 and 100. This represents the percentage of the subscription
@@ -21513,9 +21649,9 @@ paths:
                 default source, and delete the old customer default if one exists.
                 If you want to add an additional source, instead use the [card creation
                 API](https://stripe.com/docs/api#create_card) to add the card and
-                then the [customer update API](https://stripe.com/docs/api#update
-                customer) to set it as the default. Whenever you attach a card to
-                a customer, Stripe will automatically validate the card.
+                then the [customer update API](https://stripe.com/docs/api#update_customer)
+                to set it as the default. Whenever you attach a card to a customer,
+                Stripe will automatically validate the card.
             tax_percent:
               description: A non-negative decimal (with at most four decimal places)
                 between 0 and 100. This represents the percentage of the subscription

--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -4,21 +4,21 @@
       "account": {
         "properties": {
           "business_name": {
-            "description": "The publicly visible name of the business.",
+            "description": "The publicly visible name of the business",
             "nullable": true,
             "type": "string"
           },
           "business_url": {
-            "description": "The publicly visible website of the business.",
+            "description": "The publicly visible website of the business",
             "nullable": true,
             "type": "string"
           },
           "charges_enabled": {
-            "description": "Whether the account can create live charges.",
+            "description": "Whether the account can create live charges",
             "type": "boolean"
           },
           "country": {
-            "description": "The country of the account.",
+            "description": "The country of the account",
             "type": "string"
           },
           "created": {
@@ -26,22 +26,22 @@
             "type": "integer"
           },
           "debit_negative_balances": {
-            "description": "Whether Stripe will attempt to reclaim negative account balances from this account's bank account.",
+            "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
             "type": "boolean"
           },
           "decline_charge_on": {
             "$ref": "#/components/schemas/account_decline_charge_on"
           },
           "default_currency": {
-            "description": "The currency this account has chosen to use as the default.",
+            "description": "The currency this account has chosen to use as the default",
             "type": "string"
           },
           "details_submitted": {
-            "description": "Whether account details have been submitted yet. Standard accounts cannot receive transfers before this is true.",
+            "description": "Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.",
             "type": "boolean"
           },
           "display_name": {
-            "description": "The display name for this account. This is used on the Stripe dashboard to help you differentiate between accounts.",
+            "description": "The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts.",
             "nullable": true,
             "type": "string"
           },
@@ -51,7 +51,7 @@
             "type": "string"
           },
           "external_accounts": {
-            "description": "External accounts (bank accounts and/or cards) currently attached to this account.",
+            "description": "External accounts (bank accounts and debit cards) currently attached to this account",
             "properties": {
               "data": {
                 "description": "The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards.",
@@ -117,36 +117,36 @@
             "$ref": "#/components/schemas/transfer_schedule"
           },
           "payout_statement_descriptor": {
-            "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+            "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
             "nullable": true,
             "type": "string"
           },
           "payouts_enabled": {
-            "description": "Whether Stripe will send automatic transfers for this account. This is only false when Stripe is waiting for additional information from the account holder.",
+            "description": "Whether Stripe can send payouts to this account",
             "type": "boolean"
           },
           "product_description": {
-            "description": "An internal-only description of the product or service provided. This is used by Stripe in the event the account gets flagged for potential fraud.",
+            "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
             "nullable": true,
             "type": "string"
           },
           "statement_descriptor": {
-            "description": "The text that will appear on credit card statements.",
+            "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
             "nullable": true,
             "type": "string"
           },
           "support_email": {
-            "description": "A publicly shareable email address that can be reached for support for this account.",
+            "description": "A publicly shareable support email address for the business",
             "nullable": true,
             "type": "string"
           },
           "support_phone": {
-            "description": "The publicly visible support phone number for the business.",
+            "description": "A publicly shareable support phone number for the business",
             "nullable": true,
             "type": "string"
           },
           "timezone": {
-            "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
+            "description": "The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
             "nullable": true,
             "type": "string"
           },
@@ -154,7 +154,7 @@
             "$ref": "#/components/schemas/account_tos_acceptance"
           },
           "type": {
-            "description": "The type of the Stripe account. Can be `standard`, `express`, or `custom`.",
+            "description": "The Stripe account type. Can be `standard`, `express`, or `custom`.",
             "type": "string"
           },
           "verification": {
@@ -211,11 +211,11 @@
       "account_decline_charge_on": {
         "properties": {
           "avs_failure": {
-            "description": "Whether Stripe should automatically decline charges with an incorrect ZIP or postal code. This setting only applies if a card includes a ZIP or postal code and the bank specifically marks it as failed.",
+            "description": "Whether Stripe should automatically decline charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and the bank specifically marks it as failed.",
             "type": "boolean"
           },
           "cvc_failure": {
-            "description": "Whether Stripe should automatically decline charges with an incorrect CVC. This setting only applies if a card includes a CVC and the bank specifically marks it as failed.",
+            "description": "Whether Stripe should automatically decline charges with an incorrect CVC. This setting only applies when a CVC is provided and the bank specifically marks it as failed.",
             "type": "boolean"
           }
         },
@@ -232,17 +232,17 @@
       "account_tos_acceptance": {
         "properties": {
           "date": {
-            "description": "The timestamp when the account owner accepted Stripe's terms.",
+            "description": "The Unix timestamp marking when the Stripe Services Agreement was accepted by the account representative",
             "nullable": true,
             "type": "integer"
           },
           "ip": {
-            "description": "The IP address from which the account owner accepted Stripe's terms.",
+            "description": "The IP address from which the Stripe Services Agreement was accepted by the account representative",
             "nullable": true,
             "type": "string"
           },
           "user_agent": {
-            "description": "The user agent of the browser from which the user accepted Stripe's terms.",
+            "description": "The user agent of the browser from which the Stripe Services Agreement was accepted by the account representative",
             "nullable": true,
             "type": "string"
           }
@@ -256,17 +256,17 @@
       "account_verification": {
         "properties": {
           "disabled_reason": {
-            "description": "A string describing the reason for this account being unable to charge and/or transfer, if that is the case. Possible values are `rejected.fraud`, `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`, `listed`, `under_review`, or `other`.",
+            "description": "A string describing the reason for this account being unable to create charges or receive payouts, if that is the case. Can be `rejected.fraud`, `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`, `listed`, `under_review`, or `other`.",
             "nullable": true,
             "type": "string"
           },
           "due_by": {
-            "description": "At what time the `fields_needed` must be provided. If this date is in the past, the account is already in bad standing, and providing `fields_needed` is necessary to re-enable transfers and prevent other consequences. If this date is in the future, `fields_needed` must be provided to ensure the account remains in good standing.",
+            "description": "By what time the `fields_needed` must be provided. If this date is in the past, the account is already in bad standing, and providing `fields_needed` is necessary to re-enable payouts and prevent other consequences. If this date is in the future, `fields_needed` must be provided to ensure the account remains in good standing.",
             "nullable": true,
             "type": "integer"
           },
           "fields_needed": {
-            "description": "Field names that need to be provided for the account to remain in good standing. Nested fields are separated by \".\" (for example, \"legal_entity.first_name\").",
+            "description": "Field names that need to be provided for the account to remain in good standing. Nested fields are separated by `.` (for example, `legal_entity.first_name`).",
             "type": "array"
           }
         },
@@ -282,21 +282,21 @@
       "account_with_keys": {
         "properties": {
           "business_name": {
-            "description": "The publicly visible name of the business.",
+            "description": "The publicly visible name of the business",
             "nullable": true,
             "type": "string"
           },
           "business_url": {
-            "description": "The publicly visible website of the business.",
+            "description": "The publicly visible website of the business",
             "nullable": true,
             "type": "string"
           },
           "charges_enabled": {
-            "description": "Whether the account can create live charges.",
+            "description": "Whether the account can create live charges",
             "type": "boolean"
           },
           "country": {
-            "description": "The country of the account.",
+            "description": "The country of the account",
             "type": "string"
           },
           "created": {
@@ -304,22 +304,22 @@
             "type": "integer"
           },
           "debit_negative_balances": {
-            "description": "Whether Stripe will attempt to reclaim negative account balances from this account's bank account.",
+            "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
             "type": "boolean"
           },
           "decline_charge_on": {
             "$ref": "#/components/schemas/account_decline_charge_on"
           },
           "default_currency": {
-            "description": "The currency this account has chosen to use as the default.",
+            "description": "The currency this account has chosen to use as the default",
             "type": "string"
           },
           "details_submitted": {
-            "description": "Whether account details have been submitted yet. Standard accounts cannot receive transfers before this is true.",
+            "description": "Whether account details have been submitted. Standard accounts cannot receive payouts before this is true.",
             "type": "boolean"
           },
           "display_name": {
-            "description": "The display name for this account. This is used on the Stripe dashboard to help you differentiate between accounts.",
+            "description": "The display name for this account. This is used on the Stripe Dashboard to differentiate between accounts.",
             "nullable": true,
             "type": "string"
           },
@@ -329,7 +329,7 @@
             "type": "string"
           },
           "external_accounts": {
-            "description": "External accounts (bank accounts and/or cards) currently attached to this account.",
+            "description": "External accounts (bank accounts and debit cards) currently attached to this account",
             "properties": {
               "data": {
                 "description": "The list contains all external accounts that have been attached to the Stripe account. These may be bank accounts or cards.",
@@ -398,36 +398,36 @@
             "$ref": "#/components/schemas/transfer_schedule"
           },
           "payout_statement_descriptor": {
-            "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+            "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
             "nullable": true,
             "type": "string"
           },
           "payouts_enabled": {
-            "description": "Whether Stripe will send automatic transfers for this account. This is only false when Stripe is waiting for additional information from the account holder.",
+            "description": "Whether Stripe can send payouts to this account",
             "type": "boolean"
           },
           "product_description": {
-            "description": "An internal-only description of the product or service provided. This is used by Stripe in the event the account gets flagged for potential fraud.",
+            "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
             "nullable": true,
             "type": "string"
           },
           "statement_descriptor": {
-            "description": "The text that will appear on credit card statements.",
+            "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
             "nullable": true,
             "type": "string"
           },
           "support_email": {
-            "description": "A publicly shareable email address that can be reached for support for this account.",
+            "description": "A publicly shareable support email address for the business",
             "nullable": true,
             "type": "string"
           },
           "support_phone": {
-            "description": "The publicly visible support phone number for the business.",
+            "description": "A publicly shareable support phone number for the business",
             "nullable": true,
             "type": "string"
           },
           "timezone": {
-            "description": "The time zone used in the Stripe dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
+            "description": "The timezone used in the Stripe Dashboard for this account. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).",
             "nullable": true,
             "type": "string"
           },
@@ -435,7 +435,7 @@
             "$ref": "#/components/schemas/account_tos_acceptance"
           },
           "type": {
-            "description": "The type of the Stripe account. Can be `standard`, `express`, or `custom`.",
+            "description": "The Stripe account type. Can be `standard`, `express`, or `custom`.",
             "type": "string"
           },
           "verification": {
@@ -5209,8 +5209,9 @@
             "description": "Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.",
             "type": "object"
           },
-          "name": {
-            "description": "Display name of the plan.",
+          "nickname": {
+            "description": "A brief description of the plan, hidden from customers.",
+            "nullable": true,
             "type": "string"
           },
           "object": {
@@ -5220,8 +5221,8 @@
             ],
             "type": "string"
           },
-          "statement_descriptor": {
-            "description": "Displayed on customer statements when their card is charged.",
+          "product": {
+            "description": "The product whose pricing this plan determines.",
             "nullable": true,
             "type": "string"
           }
@@ -5234,7 +5235,6 @@
           "interval_count",
           "livemode",
           "metadata",
-          "name",
           "object"
         ],
         "title": "Plan",
@@ -5753,6 +5753,16 @@
             "x-expandableFields": [
               "data"
             ]
+          },
+          "statement_descriptor": {
+            "description": "Extra information about a product which will appear on your customer's credit card statement. In the case that multiple products are billed at once, the first statement descriptor will be used. Only available on products of type=`service`.",
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the product. The product is either of type `good`, which is eligible for use with Orders and SKUs, or `service`, which is eligible for use with Subscriptions and Plans.",
+            "nullable": true,
+            "type": "string"
           },
           "updated": {
             "type": "integer"
@@ -6604,6 +6614,65 @@
         "x-expandableFields": [
 
         ]
+      },
+      "source_mandate_notification": {
+        "properties": {
+          "amount": {
+            "description": "Amount associated with the mandate notification. The amount is expressed in the currency of the underlying Source. Set if the notification type is `debit_initiated`.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "created": {
+            "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "type": "string"
+          },
+          "livemode": {
+            "description": "Flag indicating whether the object exists in live mode or test mode.",
+            "type": "boolean"
+          },
+          "object": {
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "enum": [
+              "source_mandate_notification"
+            ],
+            "type": "string"
+          },
+          "reason": {
+            "description": "The reason of the mandate notification.",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/source"
+          },
+          "status": {
+            "description": "The status of the mandate notification.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of source this mandate notification is attached to.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "created",
+          "id",
+          "livemode",
+          "object",
+          "reason",
+          "source",
+          "status",
+          "type"
+        ],
+        "title": "SourceMandateNotification",
+        "type": "object",
+        "x-expandableFields": [
+          "source"
+        ],
+        "x-resourceId": "source_mandate_notification"
       },
       "source_owner": {
         "properties": {
@@ -8688,7 +8757,7 @@
     "description": "The Stripe REST API. Please see https://stripe.com/docs/api for more details.",
     "termsOfService": "https://stripe.com/us/terms/",
     "title": "Stripe API",
-    "version": "2017-12-14"
+    "version": "2018-01-15"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -8867,7 +8936,7 @@
         "operationId": "AccountRetrieve",
         "parameters": [
           {
-            "description": "The identifier of the account to be retrieved. If none is provided, will default to the account of the API key.",
+            "description": "The identifier of the account to retrieve. If none is provided, the account associated with the API key is returned.",
             "in": "query",
             "name": "account",
             "required": false,
@@ -8933,19 +9002,19 @@
                     "type": "string"
                   },
                   "business_primary_color": {
-                    "description": "A CSS hex color value representing the primary branding color for this account.",
+                    "description": "A CSS hex color value representing the primary branding color for this account",
                     "type": "string"
                   },
                   "business_url": {
-                    "description": "The URL that best shows the service or product provided for this account.",
+                    "description": "The URL that best shows the service or product provided by this account",
                     "type": "string"
                   },
                   "debit_negative_balances": {
-                    "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                    "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                     "type": "boolean"
                   },
                   "decline_charge_on": {
-                    "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                    "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                     "properties": {
                       "avs_failure": {
                         "type": "boolean"
@@ -8962,7 +9031,7 @@
                     "type": "string"
                   },
                   "email": {
-                    "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                    "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                     "type": "string"
                   },
                   "expand": {
@@ -8981,10 +9050,10 @@
                         "type": "string"
                       }
                     ],
-                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                   },
                   "legal_entity": {
-                    "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                    "description": "Information about the legal entity itself, including about the associated account representative",
                     "properties": {
                       "additional_owners": {
                         "properties": {
@@ -11437,11 +11506,11 @@
                     "type": "object"
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                     "type": "object"
                   },
                   "payout_schedule": {
-                    "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                    "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                     "properties": {
                       "delay_days": {
                         "type": "integer"
@@ -11476,39 +11545,31 @@
                     "type": "object"
                   },
                   "payout_statement_descriptor": {
-                    "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                    "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                     "type": "string"
                   },
                   "product_description": {
-                    "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                    "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                     "type": "string"
                   },
                   "statement_descriptor": {
-                    "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kana": {
-                    "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kanji": {
-                    "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                    "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                     "type": "string"
                   },
                   "support_email": {
-                    "description": "A publicly shareable email address that can be reached for support for this account.",
+                    "description": "A publicly shareable support email address for the business",
                     "type": "string"
                   },
                   "support_phone": {
-                    "description": "A publicly shareable phone number that can be reached for support for this account.",
+                    "description": "A publicly shareable support phone number for the business",
                     "type": "string"
                   },
                   "support_url": {
-                    "description": "A publicly shareable URL that can be reached for support for this account.",
+                    "description": "A publicly shareable URL that provides support for this account",
                     "type": "string"
                   },
                   "tos_acceptance": {
-                    "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                    "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                     "properties": {
                       "date": {
                         "type": "integer"
@@ -11567,7 +11628,7 @@
               "schema": {
                 "properties": {
                   "default_for_currency": {
-                    "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                    "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                     "type": "boolean"
                   },
                   "expand": {
@@ -11589,7 +11650,7 @@
                     "description": "This string to be replaced by DocSpecGenerator."
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                     "type": "object"
                   }
                 },
@@ -11734,7 +11795,7 @@
         "operationId": "UpdateAccountExternalAccount",
         "parameters": [
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -11945,7 +12006,7 @@
               "schema": {
                 "properties": {
                   "default_for_currency": {
-                    "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                    "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                     "type": "boolean"
                   },
                   "expand": {
@@ -11967,7 +12028,7 @@
                     "description": "This string to be replaced by DocSpecGenerator."
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                     "type": "object"
                   }
                 },
@@ -12112,7 +12173,7 @@
         "operationId": "UpdateAccountExternalAccount",
         "parameters": [
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -12317,7 +12378,7 @@
     },
     "/v1/accounts": {
       "get": {
-        "description": "<p>Returns a list of accounts connected to your platform via <a href=\"/docs/connect\">Connect</a>. If you’re not a platform, the list will be empty.</p>",
+        "description": "<p>Returns a list of accounts connected to your platform via <a href=\"/docs/connect\">Connect</a>. If you’re not a platform, the list is empty.</p>",
         "operationId": "AllAccount",
         "parameters": [
           {
@@ -12437,22 +12498,22 @@
                     "type": "string"
                   },
                   "business_primary_color": {
-                    "description": "A CSS hex color value representing the primary branding color for this account.",
+                    "description": "A CSS hex color value representing the primary branding color for this account",
                     "type": "string"
                   },
                   "business_url": {
-                    "description": "The URL that best shows the service or product provided for this account.",
+                    "description": "The URL that best shows the service or product provided by this account",
                     "type": "string"
                   },
                   "country": {
                     "type": "string"
                   },
                   "debit_negative_balances": {
-                    "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                    "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                     "type": "boolean"
                   },
                   "decline_charge_on": {
-                    "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                    "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                     "properties": {
                       "avs_failure": {
                         "type": "boolean"
@@ -12472,7 +12533,7 @@
                     "type": "string"
                   },
                   "email": {
-                    "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                    "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                     "type": "string"
                   },
                   "expand": {
@@ -12491,13 +12552,13 @@
                         "type": "string"
                       }
                     ],
-                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                   },
                   "from_recipient": {
                     "type": "string"
                   },
                   "legal_entity": {
-                    "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                    "description": "Information about the legal entity itself, including about the associated account representative",
                     "properties": {
                       "additional_owners": {
                         "properties": {
@@ -14953,11 +15014,11 @@
                     "type": "boolean"
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                     "type": "object"
                   },
                   "payout_schedule": {
-                    "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                    "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                     "properties": {
                       "delay_days": {
                         "type": "integer"
@@ -14992,42 +15053,34 @@
                     "type": "object"
                   },
                   "payout_statement_descriptor": {
-                    "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                    "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                     "type": "string"
                   },
                   "primary_user": {
                     "type": "string"
                   },
                   "product_description": {
-                    "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                    "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                     "type": "string"
                   },
                   "statement_descriptor": {
-                    "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kana": {
-                    "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kanji": {
-                    "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                    "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                     "type": "string"
                   },
                   "support_email": {
-                    "description": "A publicly shareable email address that can be reached for support for this account.",
+                    "description": "A publicly shareable support email address for the business",
                     "type": "string"
                   },
                   "support_phone": {
-                    "description": "A publicly shareable phone number that can be reached for support for this account.",
+                    "description": "A publicly shareable support phone number for the business",
                     "type": "string"
                   },
                   "support_url": {
-                    "description": "A publicly shareable URL that can be reached for support for this account.",
+                    "description": "A publicly shareable URL that provides support for this account",
                     "type": "string"
                   },
                   "tos_acceptance": {
-                    "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                    "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                     "properties": {
                       "date": {
                         "type": "integer"
@@ -15152,7 +15205,7 @@
         "operationId": "AccountRetrieve",
         "parameters": [
           {
-            "description": "The identifier of the account to be retrieved. If none is provided, will default to the account of the API key.",
+            "description": "The identifier of the account to retrieve. If none is provided, the account associated with the API key is returned.",
             "in": "path",
             "name": "account",
             "required": true,
@@ -15225,19 +15278,19 @@
                     "type": "string"
                   },
                   "business_primary_color": {
-                    "description": "A CSS hex color value representing the primary branding color for this account.",
+                    "description": "A CSS hex color value representing the primary branding color for this account",
                     "type": "string"
                   },
                   "business_url": {
-                    "description": "The URL that best shows the service or product provided for this account.",
+                    "description": "The URL that best shows the service or product provided by this account",
                     "type": "string"
                   },
                   "debit_negative_balances": {
-                    "description": "A Boolean for whether Stripe should try to reclaim negative balances from the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/account-balances) for more information.",
+                    "description": "A Boolean indicating if Stripe should try to reclaim negative balances from an attached bank account. See our [Understanding Connect Account Balances](/docs/connect/account-balances) documentation for details.",
                     "type": "boolean"
                   },
                   "decline_charge_on": {
-                    "description": "Account-level settings to automatically decline certain types of charges regardless of the bank's decision.",
+                    "description": "Account-level settings to automatically decline certain types of charges regardless of the decision of the card issuer.",
                     "properties": {
                       "avs_failure": {
                         "type": "boolean"
@@ -15254,7 +15307,7 @@
                     "type": "string"
                   },
                   "email": {
-                    "description": "Email address of the account holder. For Standard accounts, this is used to email them asking them to claim their Stripe account. For Custom accounts, this is only to make the account easier to identify to you: Stripe will not email the account holder.",
+                    "description": "Email address of the account representative. For Standard accounts, this is used to ask them to claim their Stripe account. For Custom accounts, this only makes the account easier to identify to platforms; Stripe does not email the account representative.",
                     "type": "string"
                   },
                   "expand": {
@@ -15273,10 +15326,10 @@
                         "type": "string"
                       }
                     ],
-                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>This will create a new external account object, make it the new default external account for its currency, and delete the old default if one exists. If you want to add additional external accounts instead of replacing the existing default for this currency, use the bank account or card creation API."
+                    "description": "A card or bank account to attach to the account. You can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js), or a dictionary as documented in the `external_account` parameter for [bank account](/docs/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API."
                   },
                   "legal_entity": {
-                    "description": "Information about the account holder; varies by [account country](#country_spec_object-verification_fields) and [account status](#account_object-verification-fields_needed).",
+                    "description": "Information about the legal entity itself, including about the associated account representative",
                     "properties": {
                       "additional_owners": {
                         "properties": {
@@ -17729,11 +17782,11 @@
                     "type": "object"
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an account object. It can be useful for storing additional information about the account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an `Account` object. It can be useful for storing additional information about the account in a structured format.",
                     "type": "object"
                   },
                   "payout_schedule": {
-                    "description": "Details on when this account will make funds from charges available, and when they will be paid out to the account holder's bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information) for more information.",
+                    "description": "Details on when funds from charges are available, and when they are paid out to an external account. See our [Setting Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information) documentation for details.",
                     "properties": {
                       "delay_days": {
                         "type": "integer"
@@ -17768,39 +17821,31 @@
                     "type": "object"
                   },
                   "payout_statement_descriptor": {
-                    "description": "The text that will appear on the account's bank account statement for payouts. If not set, this will default to your platform's bank descriptor set on the Dashboard.",
+                    "description": "The text that appears on the bank account statement for payouts. If not set, this defaults to the platform's bank descriptor as set in the Dashboard.",
                     "type": "string"
                   },
                   "product_description": {
-                    "description": "Internal-only description of the product being sold or service being provided by this account. It's used by Stripe for risk and underwriting purposes.",
+                    "description": "Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.",
                     "type": "string"
                   },
                   "statement_descriptor": {
-                    "description": "The text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kana": {
-                    "description": "The Kana variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
-                    "type": "string"
-                  },
-                  "statement_descriptor_kanji": {
-                    "description": "The Kanji variation of the text that will appear on credit card statements by default if a charge is being made [directly on the account](/docs/connect/direct-charges) (Japan only).",
+                    "description": "The default text that appears on credit card statements when a charge is made [directly on the account](/docs/connect/direct-charges)",
                     "type": "string"
                   },
                   "support_email": {
-                    "description": "A publicly shareable email address that can be reached for support for this account.",
+                    "description": "A publicly shareable support email address for the business",
                     "type": "string"
                   },
                   "support_phone": {
-                    "description": "A publicly shareable phone number that can be reached for support for this account.",
+                    "description": "A publicly shareable support phone number for the business",
                     "type": "string"
                   },
                   "support_url": {
-                    "description": "A publicly shareable URL that can be reached for support for this account.",
+                    "description": "A publicly shareable URL that provides support for this account",
                     "type": "string"
                   },
                   "tos_acceptance": {
-                    "description": "Details on who accepted the Stripe terms of service, and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance) for more information.",
+                    "description": "Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)",
                     "properties": {
                       "date": {
                         "type": "integer"
@@ -17869,7 +17914,7 @@
               "schema": {
                 "properties": {
                   "default_for_currency": {
-                    "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                    "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                     "type": "boolean"
                   },
                   "expand": {
@@ -17891,7 +17936,7 @@
                     "description": "This string to be replaced by DocSpecGenerator."
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                     "type": "object"
                   }
                 },
@@ -18060,7 +18105,7 @@
             }
           },
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -18289,7 +18334,7 @@
               "schema": {
                 "properties": {
                   "default_for_currency": {
-                    "description": "If you set this to true (or if this is the first external account being added in this currency) this account will become the default external account for its currency.",
+                    "description": "When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.",
                     "type": "boolean"
                   },
                   "expand": {
@@ -18311,7 +18356,7 @@
                     "description": "This string to be replaced by DocSpecGenerator."
                   },
                   "metadata": {
-                    "description": "A set of key/value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
+                    "description": "A set of key-value pairs that you can attach to an external account object. It can be useful for storing additional information about the external account in a structured format.",
                     "type": "object"
                   }
                 },
@@ -18480,7 +18525,7 @@
             }
           },
           {
-            "description": "The ID of the bank account to be updated.",
+            "description": "The ID of the bank account to update",
             "in": "path",
             "name": "id",
             "required": true,
@@ -18697,7 +18742,7 @@
         "operationId": "AccountReject",
         "parameters": [
           {
-            "description": "The identifier of the account to be rejected.",
+            "description": "The identifier of the account to reject",
             "in": "path",
             "name": "account",
             "required": true,
@@ -18719,7 +18764,7 @@
                     "type": "array"
                   },
                   "reason": {
-                    "description": "The reason for rejecting the account. May be one of `fraud`, `terms_of_service`, or `other`.",
+                    "description": "The reason for rejecting the account. Can be `fraud`, `terms_of_service`, or `other`.",
                     "type": "string"
                   }
                 },
@@ -20804,7 +20849,7 @@
         }
       },
       "post": {
-        "description": "<p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>, <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>",
+        "description": "<p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p><p>This request accepts only the <code>customer</code>, <code>description</code>, <code>fraud_details</code>, <code>metadata</code>, <code>receipt_email</code>, and <code>shipping</code> arguments.</p>",
         "operationId": "UpdateCharge",
         "parameters": [
           {
@@ -20821,6 +20866,10 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "properties": {
+                  "customer": {
+                    "description": "The ID of an existing customer that will be associated with this request. This field may only be updated if there is no existing associated customer with this charge.",
+                    "type": "string"
+                  },
                   "description": {
                     "description": "An arbitrary string which you can attach to a charge object. It is displayed when in the web interface alongside the charge. Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing.",
                     "type": "string"
@@ -24577,7 +24626,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                   },
                   "tax_percent": {
                     "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -24853,7 +24902,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                   },
                   "tax_percent": {
                     "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -28998,6 +29047,15 @@
             }
           },
           {
+            "description": "Only return plans for the given product.",
+            "in": "query",
+            "name": "product",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "description": "A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.",
             "in": "query",
             "name": "starting_after",
@@ -29119,8 +29177,26 @@
                     "type": "string"
                   },
                   "product": {
-                    "description": "The product whose pricing the created plan will represent.",
-                    "type": "string"
+                    "description": "The product whose pricing the created plan will represent. This can either be the ID of an existing product, or a dictionary containing fields used to create a [service product](/docs/api#product_object-type).",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "type": "object"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "statement_descriptor": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "title": "inline_product_params",
+                    "type": "object"
                   },
                   "statement_descriptor": {
                     "description": "Displayed on customer statements when their card is charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor) page for an example.",
@@ -29303,6 +29379,10 @@
                     "description": "A brief description of the plan, hidden from customers.",
                     "type": "string"
                   },
+                  "product": {
+                    "description": "The product the plan belongs to. Note that after updating, statement descriptors and line items of the plan in active subscriptions will be affected.",
+                    "type": "string"
+                  },
                   "statement_descriptor": {
                     "description": "Displayed on customer statements when their card is charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor) page for an example.",
                     "type": "string"
@@ -29408,6 +29488,19 @@
             "name": "starting_after",
             "required": false,
             "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only return products of this type.",
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "good",
+                "service"
+              ],
               "type": "string"
             }
           },
@@ -29567,6 +29660,18 @@
                   "shippable": {
                     "description": "Whether this product is shipped (i.e., physical goods). Defaults to `true`.",
                     "type": "boolean"
+                  },
+                  "statement_descriptor": {
+                    "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. The statement description may not include <>\"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all. May only be set if type=`service`.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The type of the product. The product is either of type `good`, which is eligible for use with Orders and SKUs, or `service`, which is eligible for use with Subscriptions and Plans. Defaults to type `good`.",
+                    "enum": [
+                      "good",
+                      "service"
+                    ],
+                    "type": "string"
                   },
                   "url": {
                     "description": "A URL of a publicly-accessible webpage for this product.",
@@ -29816,6 +29921,10 @@
                   "shippable": {
                     "description": "Whether this product is shipped (i.e., physical goods). Defaults to `true`.",
                     "type": "boolean"
+                  },
+                  "statement_descriptor": {
+                    "description": "An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters. The statement description may not include <>\"' characters, and will appear on your customer's statement in capital letters. Non-ASCII characters are automatically stripped. While most banks display this information consistently, some may display it incorrectly or not at all. May only be set if type=`service`.",
+                    "type": "string"
                   },
                   "url": {
                     "description": "A URL of a publicly-accessible webpage for this product.",
@@ -30674,7 +30783,7 @@
             }
           },
           {
-            "description": "The ID of the product whose SKUs will be retrieved.",
+            "description": "The ID of the product whose SKUs will be retrieved. Must be a product with type `good`.",
             "in": "query",
             "name": "product",
             "required": false,
@@ -30846,7 +30955,7 @@
                     "type": "integer"
                   },
                   "product": {
-                    "description": "The ID of the product this SKU is associated with.",
+                    "description": "The ID of the product this SKU is associated with. Must be a product with type `good`.",
                     "type": "string"
                   }
                 },
@@ -31092,7 +31201,7 @@
                     "type": "integer"
                   },
                   "product": {
-                    "description": "The ID of the product that this SKU should belong to. The product must exist and have the same set of attribute names as the SKU's current product.",
+                    "description": "The ID of the product that this SKU should belong to. The product must exist, have the same set of attribute names as the SKU's current product, and be of type `good`.",
                     "type": "string"
                   }
                 }
@@ -31372,6 +31481,53 @@
                     },
                     "type": "array"
                   },
+                  "mandate": {
+                    "properties": {
+                      "acceptance": {
+                        "properties": {
+                          "date": {
+                            "type": "integer"
+                          },
+                          "ip": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": [
+                              "accepted",
+                              "pending",
+                              "refused",
+                              "revoked"
+                            ],
+                            "type": "string"
+                          },
+                          "user_agent": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "date",
+                          "ip",
+                          "status",
+                          "user_agent"
+                        ],
+                        "title": "mandate_acceptance_params",
+                        "type": "object"
+                      },
+                      "notification_method": {
+                        "enum": [
+                          "email",
+                          "manual",
+                          "none"
+                        ],
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "title": "mandate_params",
+                    "type": "object"
+                  },
                   "metadata": {
                     "description": "A set of key/value pairs that you can attach to a source object. It can be useful for storing additional information about the source in a structured format.",
                     "type": "object"
@@ -31428,6 +31584,66 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/source"
+                }
+              }
+            },
+            "description": "Successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Error response."
+          }
+        }
+      }
+    },
+    "/v1/sources/{source}/mandate_notifications/{mandate_notification}": {
+      "get": {
+        "description": "<p>Retrieves a new Source MandateNotification.</p>",
+        "operationId": "SourceMandateNotificationRetrieve",
+        "parameters": [
+          {
+            "description": "Specifies which fields in the response should be expanded.",
+            "in": "query",
+            "name": "expand",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "The ID of the Source MandateNotification.",
+            "in": "path",
+            "name": "mandate_notification",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the Source that received a ManateNotification.",
+            "in": "path",
+            "name": "source",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/source_mandate_notification"
                 }
               }
             },
@@ -32292,7 +32508,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                   },
                   "tax_percent": {
                     "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",
@@ -32547,7 +32763,7 @@
                         "type": "string"
                       }
                     ],
-                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
+                    "description": "The source can either be a [Token](/docs/api#tokens) or a [Source](/docs/api#sources), as returned by [Elements](https://stripe.com/docs/elements), or a dictionary containing a user's credit card details (with the options shown below). You must provide a source if the customer does not already have a valid source attached, and you are subscribing the customer to be charged automatically for a plan that is not free. Passing `source` will create a new source object, make it the customer default source, and delete the old customer default if one exists. If you want to add an additional source, instead use the [card creation API](https://stripe.com/docs/api#create_card) to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer) to set it as the default. Whenever you attach a card to a customer, Stripe will automatically validate the card."
                   },
                   "tax_percent": {
                     "description": "A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount each billing period. For example, a plan which charges $10/month with a `tax_percent` of 20.0 will charge $12 per invoice.",

--- a/openapi/spec3.yaml
+++ b/openapi/spec3.yaml
@@ -4,39 +4,40 @@ components:
     account:
       properties:
         business_name:
-          description: The publicly visible name of the business.
+          description: The publicly visible name of the business
           nullable: true
           type: string
         business_url:
-          description: The publicly visible website of the business.
+          description: The publicly visible website of the business
           nullable: true
           type: string
         charges_enabled:
-          description: Whether the account can create live charges.
+          description: Whether the account can create live charges
           type: boolean
         country:
-          description: The country of the account.
+          description: The country of the account
           type: string
         created:
           description: Time at which the object was created. Measured in seconds since
             the Unix epoch.
           type: integer
         debit_negative_balances:
-          description: Whether Stripe will attempt to reclaim negative account balances
-            from this account's bank account.
+          description: A Boolean indicating if Stripe should try to reclaim negative
+            balances from an attached bank account. See our [Understanding Connect
+            Account Balances](/docs/connect/account-balances) documentation for details.
           type: boolean
         decline_charge_on:
           "$ref": "#/components/schemas/account_decline_charge_on"
         default_currency:
-          description: The currency this account has chosen to use as the default.
+          description: The currency this account has chosen to use as the default
           type: string
         details_submitted:
-          description: Whether account details have been submitted yet. Standard accounts
-            cannot receive transfers before this is true.
+          description: Whether account details have been submitted. Standard accounts
+            cannot receive payouts before this is true.
           type: boolean
         display_name:
           description: The display name for this account. This is used on the Stripe
-            dashboard to help you differentiate between accounts.
+            Dashboard to differentiate between accounts.
           nullable: true
           type: string
         email:
@@ -44,8 +45,8 @@ components:
           nullable: true
           type: string
         external_accounts:
-          description: External accounts (bank accounts and/or cards) currently attached
-            to this account.
+          description: External accounts (bank accounts and debit cards) currently
+            attached to this account
           properties:
             data:
               description: The list contains all external accounts that have been
@@ -96,37 +97,34 @@ components:
         payout_schedule:
           "$ref": "#/components/schemas/transfer_schedule"
         payout_statement_descriptor:
-          description: The text that will appear on the account's bank account statement
-            for payouts. If not set, this will default to your platform's bank descriptor
-            set on the Dashboard.
+          description: The text that appears on the bank account statement for payouts.
+            If not set, this defaults to the platform's bank descriptor as set in
+            the Dashboard.
           nullable: true
           type: string
         payouts_enabled:
-          description: Whether Stripe will send automatic transfers for this account.
-            This is only false when Stripe is waiting for additional information from
-            the account holder.
+          description: Whether Stripe can send payouts to this account
           type: boolean
         product_description:
-          description: An internal-only description of the product or service provided.
-            This is used by Stripe in the event the account gets flagged for potential
-            fraud.
+          description: Internal-only description of the product sold or service provided
+            by the business. It's used by Stripe for risk and underwriting purposes.
           nullable: true
           type: string
         statement_descriptor:
-          description: The text that will appear on credit card statements.
+          description: The default text that appears on credit card statements when
+            a charge is made [directly on the account](/docs/connect/direct-charges)
           nullable: true
           type: string
         support_email:
-          description: A publicly shareable email address that can be reached for
-            support for this account.
+          description: A publicly shareable support email address for the business
           nullable: true
           type: string
         support_phone:
-          description: The publicly visible support phone number for the business.
+          description: A publicly shareable support phone number for the business
           nullable: true
           type: string
         timezone:
-          description: The time zone used in the Stripe dashboard for this account.
+          description: The timezone used in the Stripe Dashboard for this account.
             A list of possible time zone values is maintained at the [IANA Time Zone
             Database](http://www.iana.org/time-zones).
           nullable: true
@@ -134,8 +132,7 @@ components:
         tos_acceptance:
           "$ref": "#/components/schemas/account_tos_acceptance"
         type:
-          description: The type of the Stripe account. Can be `standard`, `express`,
-            or `custom`.
+          description: The Stripe account type. Can be `standard`, `express`, or `custom`.
           type: string
         verification:
           "$ref": "#/components/schemas/account_verification"
@@ -180,13 +177,13 @@ components:
       properties:
         avs_failure:
           description: Whether Stripe should automatically decline charges with an
-            incorrect ZIP or postal code. This setting only applies if a card includes
-            a ZIP or postal code and the bank specifically marks it as failed.
+            incorrect ZIP or postal code. This setting only applies when a ZIP or
+            postal code is provided and the bank specifically marks it as failed.
           type: boolean
         cvc_failure:
           description: Whether Stripe should automatically decline charges with an
-            incorrect CVC. This setting only applies if a card includes a CVC and
-            the bank specifically marks it as failed.
+            incorrect CVC. This setting only applies when a CVC is provided and the
+            bank specifically marks it as failed.
           type: boolean
       required:
       - avs_failure
@@ -197,17 +194,18 @@ components:
     account_tos_acceptance:
       properties:
         date:
-          description: The timestamp when the account owner accepted Stripe's terms.
+          description: The Unix timestamp marking when the Stripe Services Agreement
+            was accepted by the account representative
           nullable: true
           type: integer
         ip:
-          description: The IP address from which the account owner accepted Stripe's
-            terms.
+          description: The IP address from which the Stripe Services Agreement was
+            accepted by the account representative
           nullable: true
           type: string
         user_agent:
-          description: The user agent of the browser from which the user accepted
-            Stripe's terms.
+          description: The user agent of the browser from which the Stripe Services
+            Agreement was accepted by the account representative
           nullable: true
           type: string
       title: AccountTOSAcceptance
@@ -217,22 +215,22 @@ components:
       properties:
         disabled_reason:
           description: A string describing the reason for this account being unable
-            to charge and/or transfer, if that is the case. Possible values are `rejected.fraud`,
+            to create charges or receive payouts, if that is the case. Can be `rejected.fraud`,
             `rejected.terms_of_service`, `rejected.listed`, `rejected.other`, `fields_needed`,
             `listed`, `under_review`, or `other`.
           nullable: true
           type: string
         due_by:
-          description: At what time the `fields_needed` must be provided. If this
+          description: By what time the `fields_needed` must be provided. If this
             date is in the past, the account is already in bad standing, and providing
-            `fields_needed` is necessary to re-enable transfers and prevent other
-            consequences. If this date is in the future, `fields_needed` must be provided
-            to ensure the account remains in good standing.
+            `fields_needed` is necessary to re-enable payouts and prevent other consequences.
+            If this date is in the future, `fields_needed` must be provided to ensure
+            the account remains in good standing.
           nullable: true
           type: integer
         fields_needed:
           description: Field names that need to be provided for the account to remain
-            in good standing. Nested fields are separated by "." (for example, "legal_entity.first_name").
+            in good standing. Nested fields are separated by `.` (for example, `legal_entity.first_name`).
           type: array
       required:
       - fields_needed
@@ -242,39 +240,40 @@ components:
     account_with_keys:
       properties:
         business_name:
-          description: The publicly visible name of the business.
+          description: The publicly visible name of the business
           nullable: true
           type: string
         business_url:
-          description: The publicly visible website of the business.
+          description: The publicly visible website of the business
           nullable: true
           type: string
         charges_enabled:
-          description: Whether the account can create live charges.
+          description: Whether the account can create live charges
           type: boolean
         country:
-          description: The country of the account.
+          description: The country of the account
           type: string
         created:
           description: Time at which the object was created. Measured in seconds since
             the Unix epoch.
           type: integer
         debit_negative_balances:
-          description: Whether Stripe will attempt to reclaim negative account balances
-            from this account's bank account.
+          description: A Boolean indicating if Stripe should try to reclaim negative
+            balances from an attached bank account. See our [Understanding Connect
+            Account Balances](/docs/connect/account-balances) documentation for details.
           type: boolean
         decline_charge_on:
           "$ref": "#/components/schemas/account_decline_charge_on"
         default_currency:
-          description: The currency this account has chosen to use as the default.
+          description: The currency this account has chosen to use as the default
           type: string
         details_submitted:
-          description: Whether account details have been submitted yet. Standard accounts
-            cannot receive transfers before this is true.
+          description: Whether account details have been submitted. Standard accounts
+            cannot receive payouts before this is true.
           type: boolean
         display_name:
           description: The display name for this account. This is used on the Stripe
-            dashboard to help you differentiate between accounts.
+            Dashboard to differentiate between accounts.
           nullable: true
           type: string
         email:
@@ -282,8 +281,8 @@ components:
           nullable: true
           type: string
         external_accounts:
-          description: External accounts (bank accounts and/or cards) currently attached
-            to this account.
+          description: External accounts (bank accounts and debit cards) currently
+            attached to this account
           properties:
             data:
               description: The list contains all external accounts that have been
@@ -336,37 +335,34 @@ components:
         payout_schedule:
           "$ref": "#/components/schemas/transfer_schedule"
         payout_statement_descriptor:
-          description: The text that will appear on the account's bank account statement
-            for payouts. If not set, this will default to your platform's bank descriptor
-            set on the Dashboard.
+          description: The text that appears on the bank account statement for payouts.
+            If not set, this defaults to the platform's bank descriptor as set in
+            the Dashboard.
           nullable: true
           type: string
         payouts_enabled:
-          description: Whether Stripe will send automatic transfers for this account.
-            This is only false when Stripe is waiting for additional information from
-            the account holder.
+          description: Whether Stripe can send payouts to this account
           type: boolean
         product_description:
-          description: An internal-only description of the product or service provided.
-            This is used by Stripe in the event the account gets flagged for potential
-            fraud.
+          description: Internal-only description of the product sold or service provided
+            by the business. It's used by Stripe for risk and underwriting purposes.
           nullable: true
           type: string
         statement_descriptor:
-          description: The text that will appear on credit card statements.
+          description: The default text that appears on credit card statements when
+            a charge is made [directly on the account](/docs/connect/direct-charges)
           nullable: true
           type: string
         support_email:
-          description: A publicly shareable email address that can be reached for
-            support for this account.
+          description: A publicly shareable support email address for the business
           nullable: true
           type: string
         support_phone:
-          description: The publicly visible support phone number for the business.
+          description: A publicly shareable support phone number for the business
           nullable: true
           type: string
         timezone:
-          description: The time zone used in the Stripe dashboard for this account.
+          description: The timezone used in the Stripe Dashboard for this account.
             A list of possible time zone values is maintained at the [IANA Time Zone
             Database](http://www.iana.org/time-zones).
           nullable: true
@@ -374,8 +370,7 @@ components:
         tos_acceptance:
           "$ref": "#/components/schemas/account_tos_acceptance"
         type:
-          description: The type of the Stripe account. Can be `standard`, `express`,
-            or `custom`.
+          description: The Stripe account type. Can be `standard`, `express`, or `custom`.
           type: string
         verification:
           "$ref": "#/components/schemas/account_verification"
@@ -4091,8 +4086,9 @@ components:
             can be useful for storing additional information about the object in a
             structured format.
           type: object
-        name:
-          description: Display name of the plan.
+        nickname:
+          description: A brief description of the plan, hidden from customers.
+          nullable: true
           type: string
         object:
           description: String representing the object's type. Objects of the same
@@ -4100,8 +4096,8 @@ components:
           enum:
           - plan
           type: string
-        statement_descriptor:
-          description: Displayed on customer statements when their card is charged.
+        product:
+          description: The product whose pricing this plan determines.
           nullable: true
           type: string
       required:
@@ -4112,7 +4108,6 @@ components:
       - interval_count
       - livemode
       - metadata
-      - name
       - object
       title: Plan
       type: object
@@ -4476,6 +4471,19 @@ components:
           type: object
           x-expandableFields:
           - data
+        statement_descriptor:
+          description: Extra information about a product which will appear on your
+            customer's credit card statement. In the case that multiple products are
+            billed at once, the first statement descriptor will be used. Only available
+            on products of type=`service`.
+          nullable: true
+          type: string
+        type:
+          description: The type of the product. The product is either of type `good`,
+            which is eligible for use with Orders and SKUs, or `service`, which is
+            eligible for use with Subscriptions and Plans.
+          nullable: true
+          type: string
         updated:
           type: integer
         url:
@@ -5146,6 +5154,56 @@ components:
       title: SourceCodeVerificationFlow
       type: object
       x-expandableFields: []
+    source_mandate_notification:
+      properties:
+        amount:
+          description: Amount associated with the mandate notification. The amount
+            is expressed in the currency of the underlying Source. Set if the notification
+            type is `debit_initiated`.
+          nullable: true
+          type: integer
+        created:
+          description: Time at which the object was created. Measured in seconds since
+            the Unix epoch.
+          type: integer
+        id:
+          description: Unique identifier for the object.
+          type: string
+        livemode:
+          description: Flag indicating whether the object exists in live mode or test
+            mode.
+          type: boolean
+        object:
+          description: String representing the object's type. Objects of the same
+            type share the same value.
+          enum:
+          - source_mandate_notification
+          type: string
+        reason:
+          description: The reason of the mandate notification.
+          type: string
+        source:
+          "$ref": "#/components/schemas/source"
+        status:
+          description: The status of the mandate notification.
+          type: string
+        type:
+          description: The type of source this mandate notification is attached to.
+          type: string
+      required:
+      - created
+      - id
+      - livemode
+      - object
+      - reason
+      - source
+      - status
+      - type
+      title: SourceMandateNotification
+      type: object
+      x-expandableFields:
+      - source
+      x-resourceId: source_mandate_notification
     source_owner:
       properties:
         address:
@@ -6850,7 +6908,7 @@ info:
     details.
   termsOfService: https://stripe.com/us/terms/
   title: Stripe API
-  version: '2017-12-14'
+  version: '2018-01-15'
 openapi: 3.0.0
 paths:
   "/v1/3d_secure":
@@ -6976,8 +7034,8 @@ paths:
       description: "<p>Retrieves the details of the account.</p>"
       operationId: AccountRetrieve
       parameters:
-      - description: The identifier of the account to be retrieved. If none is provided,
-          will default to the account of the API key.
+      - description: The identifier of the account to retrieve. If none is provided,
+          the account associated with the API key is returned.
         in: query
         name: account
         required: false
@@ -7028,21 +7086,21 @@ paths:
                   type: string
                 business_primary_color:
                   description: A CSS hex color value representing the primary branding
-                    color for this account.
+                    color for this account
                   type: string
                 business_url:
                   description: The URL that best shows the service or product provided
-                    for this account.
+                    by this account
                   type: string
                 debit_negative_balances:
-                  description: A Boolean for whether Stripe should try to reclaim
-                    negative balances from the account holder's bank account. See
-                    our [Connect account bank transfer guide](/docs/connect/account-balances)
-                    for more information.
+                  description: A Boolean indicating if Stripe should try to reclaim
+                    negative balances from an attached bank account. See our [Understanding
+                    Connect Account Balances](/docs/connect/account-balances) documentation
+                    for details.
                   type: boolean
                 decline_charge_on:
                   description: Account-level settings to automatically decline certain
-                    types of charges regardless of the bank's decision.
+                    types of charges regardless of the decision of the card issuer.
                   properties:
                     avs_failure:
                       type: boolean
@@ -7056,11 +7114,10 @@ paths:
                     supports in the account's country](https://stripe.com/docs/payouts).
                   type: string
                 email:
-                  description: 'Email address of the account holder. For Standard
-                    accounts, this is used to email them asking them to claim their
-                    Stripe account. For Custom accounts, this is only to make the
-                    account easier to identify to you: Stripe will not email the account
-                    holder.'
+                  description: Email address of the account representative. For Standard
+                    accounts, this is used to ask them to claim their Stripe account.
+                    For Custom accounts, this only makes the account easier to identify
+                    to platforms; Stripe does not email the account representative.
                   type: string
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -7075,15 +7132,14 @@ paths:
                     can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                     or a dictionary as documented in the `external_account` parameter
                     for [bank account](/docs/api#account_create_bank_account) creation.
-                    <br><br>This will create a new external account object, make it
-                    the new default external account for its currency, and delete
-                    the old default if one exists. If you want to add additional external
-                    accounts instead of replacing the existing default for this currency,
-                    use the bank account or card creation API.
+                    <br><br>By default, providing an external account sets it as the
+                    new default external account for its currency and deletes the
+                    old default if one exists. To add additional external accounts
+                    without replacing the existing default for the currency, use the
+                    bank account or card creation API.
                 legal_entity:
-                  description: Information about the account holder; varies by [account
-                    country](#country_spec_object-verification_fields) and [account
-                    status](#account_object-verification-fields_needed).
+                  description: Information about the legal entity itself, including
+                    about the associated account representative
                   properties:
                     additional_owners:
                       properties:
@@ -8740,15 +8796,15 @@ paths:
                   title: account_legal_entity_specs
                   type: object
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
-                    account object. It can be useful for storing additional information
+                  description: A set of key-value pairs that you can attach to an
+                    `Account` object. It can be useful for storing additional information
                     about the account in a structured format.
                   type: object
                 payout_schedule:
-                  description: Details on when this account will make funds from charges
-                    available, and when they will be paid out to the account holder's
-                    bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                    for more information.
+                  description: Details on when funds from charges are available, and
+                    when they are paid out to an external account. See our [Setting
+                    Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                    documentation for details.
                   properties:
                     delay_days:
                       type: integer
@@ -8775,45 +8831,32 @@ paths:
                   title: transfer_schedule_specs
                   type: object
                 payout_statement_descriptor:
-                  description: The text that will appear on the account's bank account
-                    statement for payouts. If not set, this will default to your platform's
-                    bank descriptor set on the Dashboard.
+                  description: The text that appears on the bank account statement
+                    for payouts. If not set, this defaults to the platform's bank
+                    descriptor as set in the Dashboard.
                   type: string
                 product_description:
-                  description: Internal-only description of the product being sold
-                    or service being provided by this account. It's used by Stripe
-                    for risk and underwriting purposes.
+                  description: Internal-only description of the product sold or service
+                    provided by the business. It's used by Stripe for risk and underwriting
+                    purposes.
                   type: string
                 statement_descriptor:
-                  description: The text that will appear on credit card statements
-                    by default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-                  type: string
-                statement_descriptor_kana:
-                  description: The Kana variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
-                  type: string
-                statement_descriptor_kanji:
-                  description: The Kanji variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
+                  description: The default text that appears on credit card statements
+                    when a charge is made [directly on the account](/docs/connect/direct-charges)
                   type: string
                 support_email:
-                  description: A publicly shareable email address that can be reached
-                    for support for this account.
+                  description: A publicly shareable support email address for the
+                    business
                   type: string
                 support_phone:
-                  description: A publicly shareable phone number that can be reached
-                    for support for this account.
+                  description: A publicly shareable support phone number for the business
                   type: string
                 support_url:
-                  description: A publicly shareable URL that can be reached for support
-                    for this account.
+                  description: A publicly shareable URL that provides support for
+                    this account
                   type: string
                 tos_acceptance:
-                  description: Details on who accepted the Stripe terms of service,
-                    and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                    for more information.
+                  description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
                   properties:
                     date:
                       type: integer
@@ -8850,9 +8893,9 @@ paths:
             schema:
               properties:
                 default_for_currency:
-                  description: If you set this to true (or if this is the first external
-                    account being added in this currency) this account will become
-                    the default external account for its currency.
+                  description: When set to true, or if this is the first external
+                    account added in this currency, this account becomes the default
+                    external account for its currency.
                   type: boolean
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -8865,7 +8908,7 @@ paths:
                   - type: string
                   description: This string to be replaced by DocSpecGenerator.
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
+                  description: A set of key-value pairs that you can attach to an
                     external account object. It can be useful for storing additional
                     information about the external account in a structured format.
                   type: object
@@ -8958,7 +9001,7 @@ paths:
         or changes.</p>
       operationId: UpdateAccountExternalAccount
       parameters:
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -9115,9 +9158,9 @@ paths:
             schema:
               properties:
                 default_for_currency:
-                  description: If you set this to true (or if this is the first external
-                    account being added in this currency) this account will become
-                    the default external account for its currency.
+                  description: When set to true, or if this is the first external
+                    account added in this currency, this account becomes the default
+                    external account for its currency.
                   type: boolean
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -9130,7 +9173,7 @@ paths:
                   - type: string
                   description: This string to be replaced by DocSpecGenerator.
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
+                  description: A set of key-value pairs that you can attach to an
                     external account object. It can be useful for storing additional
                     information about the external account in a structured format.
                   type: object
@@ -9223,7 +9266,7 @@ paths:
         or changes.</p>
       operationId: UpdateAccountExternalAccount
       parameters:
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -9366,8 +9409,7 @@ paths:
   "/v1/accounts":
     get:
       description: <p>Returns a list of accounts connected to your platform via <a
-        href="/docs/connect">Connect</a>. If you’re not a platform, the list will
-        be empty.</p>
+        href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.</p>
       operationId: AllAccount
       parameters:
       - description: A cursor for use in pagination. `ending_before` is an object
@@ -9462,23 +9504,23 @@ paths:
                   type: string
                 business_primary_color:
                   description: A CSS hex color value representing the primary branding
-                    color for this account.
+                    color for this account
                   type: string
                 business_url:
                   description: The URL that best shows the service or product provided
-                    for this account.
+                    by this account
                   type: string
                 country:
                   type: string
                 debit_negative_balances:
-                  description: A Boolean for whether Stripe should try to reclaim
-                    negative balances from the account holder's bank account. See
-                    our [Connect account bank transfer guide](/docs/connect/account-balances)
-                    for more information.
+                  description: A Boolean indicating if Stripe should try to reclaim
+                    negative balances from an attached bank account. See our [Understanding
+                    Connect Account Balances](/docs/connect/account-balances) documentation
+                    for details.
                   type: boolean
                 decline_charge_on:
                   description: Account-level settings to automatically decline certain
-                    types of charges regardless of the bank's decision.
+                    types of charges regardless of the decision of the card issuer.
                   properties:
                     avs_failure:
                       type: boolean
@@ -9494,11 +9536,10 @@ paths:
                 display_name:
                   type: string
                 email:
-                  description: 'Email address of the account holder. For Standard
-                    accounts, this is used to email them asking them to claim their
-                    Stripe account. For Custom accounts, this is only to make the
-                    account easier to identify to you: Stripe will not email the account
-                    holder.'
+                  description: Email address of the account representative. For Standard
+                    accounts, this is used to ask them to claim their Stripe account.
+                    For Custom accounts, this only makes the account easier to identify
+                    to platforms; Stripe does not email the account representative.
                   type: string
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -9513,17 +9554,16 @@ paths:
                     can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                     or a dictionary as documented in the `external_account` parameter
                     for [bank account](/docs/api#account_create_bank_account) creation.
-                    <br><br>This will create a new external account object, make it
-                    the new default external account for its currency, and delete
-                    the old default if one exists. If you want to add additional external
-                    accounts instead of replacing the existing default for this currency,
-                    use the bank account or card creation API.
+                    <br><br>By default, providing an external account sets it as the
+                    new default external account for its currency and deletes the
+                    old default if one exists. To add additional external accounts
+                    without replacing the existing default for the currency, use the
+                    bank account or card creation API.
                 from_recipient:
                   type: string
                 legal_entity:
-                  description: Information about the account holder; varies by [account
-                    country](#country_spec_object-verification_fields) and [account
-                    status](#account_object-verification-fields_needed).
+                  description: Information about the legal entity itself, including
+                    about the associated account representative
                   properties:
                     additional_owners:
                       properties:
@@ -11182,15 +11222,15 @@ paths:
                 make_ready_for_panda:
                   type: boolean
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
-                    account object. It can be useful for storing additional information
+                  description: A set of key-value pairs that you can attach to an
+                    `Account` object. It can be useful for storing additional information
                     about the account in a structured format.
                   type: object
                 payout_schedule:
-                  description: Details on when this account will make funds from charges
-                    available, and when they will be paid out to the account holder's
-                    bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                    for more information.
+                  description: Details on when funds from charges are available, and
+                    when they are paid out to an external account. See our [Setting
+                    Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                    documentation for details.
                   properties:
                     delay_days:
                       type: integer
@@ -11217,47 +11257,34 @@ paths:
                   title: transfer_schedule_specs
                   type: object
                 payout_statement_descriptor:
-                  description: The text that will appear on the account's bank account
-                    statement for payouts. If not set, this will default to your platform's
-                    bank descriptor set on the Dashboard.
+                  description: The text that appears on the bank account statement
+                    for payouts. If not set, this defaults to the platform's bank
+                    descriptor as set in the Dashboard.
                   type: string
                 primary_user:
                   type: string
                 product_description:
-                  description: Internal-only description of the product being sold
-                    or service being provided by this account. It's used by Stripe
-                    for risk and underwriting purposes.
+                  description: Internal-only description of the product sold or service
+                    provided by the business. It's used by Stripe for risk and underwriting
+                    purposes.
                   type: string
                 statement_descriptor:
-                  description: The text that will appear on credit card statements
-                    by default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-                  type: string
-                statement_descriptor_kana:
-                  description: The Kana variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
-                  type: string
-                statement_descriptor_kanji:
-                  description: The Kanji variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
+                  description: The default text that appears on credit card statements
+                    when a charge is made [directly on the account](/docs/connect/direct-charges)
                   type: string
                 support_email:
-                  description: A publicly shareable email address that can be reached
-                    for support for this account.
+                  description: A publicly shareable support email address for the
+                    business
                   type: string
                 support_phone:
-                  description: A publicly shareable phone number that can be reached
-                    for support for this account.
+                  description: A publicly shareable support phone number for the business
                   type: string
                 support_url:
-                  description: A publicly shareable URL that can be reached for support
-                    for this account.
+                  description: A publicly shareable URL that provides support for
+                    this account
                   type: string
                 tos_acceptance:
-                  description: Details on who accepted the Stripe terms of service,
-                    and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                    for more information.
+                  description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
                   properties:
                     date:
                       type: integer
@@ -11337,8 +11364,8 @@ paths:
       description: "<p>Retrieves the details of the account.</p>"
       operationId: AccountRetrieve
       parameters:
-      - description: The identifier of the account to be retrieved. If none is provided,
-          will default to the account of the API key.
+      - description: The identifier of the account to retrieve. If none is provided,
+          the account associated with the API key is returned.
         in: path
         name: account
         required: true
@@ -11393,21 +11420,21 @@ paths:
                   type: string
                 business_primary_color:
                   description: A CSS hex color value representing the primary branding
-                    color for this account.
+                    color for this account
                   type: string
                 business_url:
                   description: The URL that best shows the service or product provided
-                    for this account.
+                    by this account
                   type: string
                 debit_negative_balances:
-                  description: A Boolean for whether Stripe should try to reclaim
-                    negative balances from the account holder's bank account. See
-                    our [Connect account bank transfer guide](/docs/connect/account-balances)
-                    for more information.
+                  description: A Boolean indicating if Stripe should try to reclaim
+                    negative balances from an attached bank account. See our [Understanding
+                    Connect Account Balances](/docs/connect/account-balances) documentation
+                    for details.
                   type: boolean
                 decline_charge_on:
                   description: Account-level settings to automatically decline certain
-                    types of charges regardless of the bank's decision.
+                    types of charges regardless of the decision of the card issuer.
                   properties:
                     avs_failure:
                       type: boolean
@@ -11421,11 +11448,10 @@ paths:
                     supports in the account's country](https://stripe.com/docs/payouts).
                   type: string
                 email:
-                  description: 'Email address of the account holder. For Standard
-                    accounts, this is used to email them asking them to claim their
-                    Stripe account. For Custom accounts, this is only to make the
-                    account easier to identify to you: Stripe will not email the account
-                    holder.'
+                  description: Email address of the account representative. For Standard
+                    accounts, this is used to ask them to claim their Stripe account.
+                    For Custom accounts, this only makes the account easier to identify
+                    to platforms; Stripe does not email the account representative.
                   type: string
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -11440,15 +11466,14 @@ paths:
                     can provide either a token, like the ones returned by [Stripe.js](/docs/stripe.js),
                     or a dictionary as documented in the `external_account` parameter
                     for [bank account](/docs/api#account_create_bank_account) creation.
-                    <br><br>This will create a new external account object, make it
-                    the new default external account for its currency, and delete
-                    the old default if one exists. If you want to add additional external
-                    accounts instead of replacing the existing default for this currency,
-                    use the bank account or card creation API.
+                    <br><br>By default, providing an external account sets it as the
+                    new default external account for its currency and deletes the
+                    old default if one exists. To add additional external accounts
+                    without replacing the existing default for the currency, use the
+                    bank account or card creation API.
                 legal_entity:
-                  description: Information about the account holder; varies by [account
-                    country](#country_spec_object-verification_fields) and [account
-                    status](#account_object-verification-fields_needed).
+                  description: Information about the legal entity itself, including
+                    about the associated account representative
                   properties:
                     additional_owners:
                       properties:
@@ -13105,15 +13130,15 @@ paths:
                   title: account_legal_entity_specs
                   type: object
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
-                    account object. It can be useful for storing additional information
+                  description: A set of key-value pairs that you can attach to an
+                    `Account` object. It can be useful for storing additional information
                     about the account in a structured format.
                   type: object
                 payout_schedule:
-                  description: Details on when this account will make funds from charges
-                    available, and when they will be paid out to the account holder's
-                    bank account. See our [Connect account bank transfer guide](/docs/connect/bank-transfers#payout-information)
-                    for more information.
+                  description: Details on when funds from charges are available, and
+                    when they are paid out to an external account. See our [Setting
+                    Bank and Debit Card Payouts](/docs/connect/bank-transfers#payout-information)
+                    documentation for details.
                   properties:
                     delay_days:
                       type: integer
@@ -13140,45 +13165,32 @@ paths:
                   title: transfer_schedule_specs
                   type: object
                 payout_statement_descriptor:
-                  description: The text that will appear on the account's bank account
-                    statement for payouts. If not set, this will default to your platform's
-                    bank descriptor set on the Dashboard.
+                  description: The text that appears on the bank account statement
+                    for payouts. If not set, this defaults to the platform's bank
+                    descriptor as set in the Dashboard.
                   type: string
                 product_description:
-                  description: Internal-only description of the product being sold
-                    or service being provided by this account. It's used by Stripe
-                    for risk and underwriting purposes.
+                  description: Internal-only description of the product sold or service
+                    provided by the business. It's used by Stripe for risk and underwriting
+                    purposes.
                   type: string
                 statement_descriptor:
-                  description: The text that will appear on credit card statements
-                    by default if a charge is being made [directly on the account](/docs/connect/direct-charges).
-                  type: string
-                statement_descriptor_kana:
-                  description: The Kana variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
-                  type: string
-                statement_descriptor_kanji:
-                  description: The Kanji variation of the text that will appear on
-                    credit card statements by default if a charge is being made [directly
-                    on the account](/docs/connect/direct-charges) (Japan only).
+                  description: The default text that appears on credit card statements
+                    when a charge is made [directly on the account](/docs/connect/direct-charges)
                   type: string
                 support_email:
-                  description: A publicly shareable email address that can be reached
-                    for support for this account.
+                  description: A publicly shareable support email address for the
+                    business
                   type: string
                 support_phone:
-                  description: A publicly shareable phone number that can be reached
-                    for support for this account.
+                  description: A publicly shareable support phone number for the business
                   type: string
                 support_url:
-                  description: A publicly shareable URL that can be reached for support
-                    for this account.
+                  description: A publicly shareable URL that provides support for
+                    this account
                   type: string
                 tos_acceptance:
-                  description: Details on who accepted the Stripe terms of service,
-                    and when they accepted it. See our [updating accounts guide](/docs/connect/updating-accounts#tos-acceptance)
-                    for more information.
+                  description: Details on the [acceptance of the Stripe Services Agreement](/docs/connect/updating-accounts#tos-acceptance)
                   properties:
                     date:
                       type: integer
@@ -13221,9 +13233,9 @@ paths:
             schema:
               properties:
                 default_for_currency:
-                  description: If you set this to true (or if this is the first external
-                    account being added in this currency) this account will become
-                    the default external account for its currency.
+                  description: When set to true, or if this is the first external
+                    account added in this currency, this account becomes the default
+                    external account for its currency.
                   type: boolean
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -13236,7 +13248,7 @@ paths:
                   - type: string
                   description: This string to be replaced by DocSpecGenerator.
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
+                  description: A set of key-value pairs that you can attach to an
                     external account object. It can be useful for storing additional
                     information about the external account in a structured format.
                   type: object
@@ -13344,7 +13356,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -13512,9 +13524,9 @@ paths:
             schema:
               properties:
                 default_for_currency:
-                  description: If you set this to true (or if this is the first external
-                    account being added in this currency) this account will become
-                    the default external account for its currency.
+                  description: When set to true, or if this is the first external
+                    account added in this currency, this account becomes the default
+                    external account for its currency.
                   type: boolean
                 expand:
                   description: Specifies which fields in the response should be expanded.
@@ -13527,7 +13539,7 @@ paths:
                   - type: string
                   description: This string to be replaced by DocSpecGenerator.
                 metadata:
-                  description: A set of key/value pairs that you can attach to an
+                  description: A set of key-value pairs that you can attach to an
                     external account object. It can be useful for storing additional
                     information about the external account in a structured format.
                   type: object
@@ -13635,7 +13647,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: The ID of the bank account to be updated.
+      - description: The ID of the bank account to update
         in: path
         name: id
         required: true
@@ -13786,7 +13798,7 @@ paths:
         all balances are zero.</p>
       operationId: AccountReject
       parameters:
-      - description: The identifier of the account to be rejected.
+      - description: The identifier of the account to reject
         in: path
         name: account
         required: true
@@ -13803,8 +13815,8 @@ paths:
                     type: string
                   type: array
                 reason:
-                  description: The reason for rejecting the account. May be one of
-                    `fraud`, `terms_of_service`, or `other`.
+                  description: The reason for rejecting the account. Can be `fraud`,
+                    `terms_of_service`, or `other`.
                   type: string
               required:
               - reason
@@ -15267,8 +15279,9 @@ paths:
     post:
       description: "<p>Updates the specified charge by setting the values of the parameters
         passed. Any parameters not provided will be left unchanged.</p><p>This request
-        accepts only the <code>description</code>, <code>metadata</code>, <code>receipt_email</code>,
-        <code>fraud_details</code>, and <code>shipping</code> as arguments.</p>"
+        accepts only the <code>customer</code>, <code>description</code>, <code>fraud_details</code>,
+        <code>metadata</code>, <code>receipt_email</code>, and <code>shipping</code>
+        arguments.</p>"
       operationId: UpdateCharge
       parameters:
       - in: path
@@ -15281,6 +15294,11 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               properties:
+                customer:
+                  description: The ID of an existing customer that will be associated
+                    with this request. This field may only be updated if there is
+                    no existing associated customer with this charge.
+                  type: string
                 description:
                   description: An arbitrary string which you can attach to a charge
                     object. It is displayed when in the web interface alongside the
@@ -17956,9 +17974,9 @@ paths:
                     the customer default source, and delete the old customer default
                     if one exists. If you want to add an additional source, instead
                     use the [card creation API](https://stripe.com/docs/api#create_card)
-                    to add the card and then the [customer update API](https://stripe.com/docs/api#update
-                    customer) to set it as the default. Whenever you attach a card
-                    to a customer, Stripe will automatically validate the card.
+                    to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer)
+                    to set it as the default. Whenever you attach a card to a customer,
+                    Stripe will automatically validate the card.
                 tax_percent:
                   description: A non-negative decimal (with at most four decimal places)
                     between 0 and 100. This represents the percentage of the subscription
@@ -18191,9 +18209,9 @@ paths:
                     the customer default source, and delete the old customer default
                     if one exists. If you want to add an additional source, instead
                     use the [card creation API](https://stripe.com/docs/api#create_card)
-                    to add the card and then the [customer update API](https://stripe.com/docs/api#update
-                    customer) to set it as the default. Whenever you attach a card
-                    to a customer, Stripe will automatically validate the card.
+                    to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer)
+                    to set it as the default. Whenever you attach a card to a customer,
+                    Stripe will automatically validate the card.
                 tax_percent:
                   description: A non-negative decimal (with at most four decimal places)
                     between 0 and 100. This represents the percentage of the subscription
@@ -21254,6 +21272,12 @@ paths:
         required: false
         schema:
           type: integer
+      - description: Only return plans for the given product.
+        in: query
+        name: product
+        required: false
+        schema:
+          type: string
       - description: A cursor for use in pagination. `starting_after` is an object
           ID that defines your place in the list. For instance, if you make a list
           request and receive 100 objects, ending with `obj_foo`, your subsequent
@@ -21360,7 +21384,21 @@ paths:
                   type: string
                 product:
                   description: The product whose pricing the created plan will represent.
-                  type: string
+                    This can either be the ID of an existing product, or a dictionary
+                    containing fields used to create a [service product](/docs/api#product_object-type).
+                  properties:
+                    id:
+                      type: string
+                    metadata:
+                      type: object
+                    name:
+                      type: string
+                    statement_descriptor:
+                      type: string
+                  required:
+                  - name
+                  title: inline_product_params
+                  type: object
                 statement_descriptor:
                   description: Displayed on customer statements when their card is
                     charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor)
@@ -21485,6 +21523,11 @@ paths:
                 nickname:
                   description: A brief description of the plan, hidden from customers.
                   type: string
+                product:
+                  description: The product the plan belongs to. Note that after updating,
+                    statement descriptors and line items of the plan in active subscriptions
+                    will be affected.
+                  type: string
                 statement_descriptor:
                   description: Displayed on customer statements when their card is
                     charged. See the [Creating charges](https://stripe.com/docs/charges#dynamic-statement-descriptor)
@@ -21567,6 +21610,15 @@ paths:
         name: starting_after
         required: false
         schema:
+          type: string
+      - description: Only return products of this type.
+        in: query
+        name: type
+        required: false
+        schema:
+          enum:
+          - good
+          - service
           type: string
       - description: Only return products with the given url.
         in: query
@@ -21694,6 +21746,24 @@ paths:
                   description: Whether this product is shipped (i.e., physical goods).
                     Defaults to `true`.
                   type: boolean
+                statement_descriptor:
+                  description: An arbitrary string to be displayed on your customer's
+                    credit card statement. This may be up to 22 characters. The statement
+                    description may not include <>"' characters, and will appear on
+                    your customer's statement in capital letters. Non-ASCII characters
+                    are automatically stripped. While most banks display this information
+                    consistently, some may display it incorrectly or not at all. May
+                    only be set if type=`service`.
+                  type: string
+                type:
+                  description: The type of the product. The product is either of type
+                    `good`, which is eligible for use with Orders and SKUs, or `service`,
+                    which is eligible for use with Subscriptions and Plans. Defaults
+                    to type `good`.
+                  enum:
+                  - good
+                  - service
+                  type: string
                 url:
                   description: A URL of a publicly-accessible webpage for this product.
                   type: string
@@ -21871,6 +21941,15 @@ paths:
                   description: Whether this product is shipped (i.e., physical goods).
                     Defaults to `true`.
                   type: boolean
+                statement_descriptor:
+                  description: An arbitrary string to be displayed on your customer's
+                    credit card statement. This may be up to 22 characters. The statement
+                    description may not include <>"' characters, and will appear on
+                    your customer's statement in capital letters. Non-ASCII characters
+                    are automatically stripped. While most banks display this information
+                    consistently, some may display it incorrectly or not at all. May
+                    only be set if type=`service`.
+                  type: string
                 url:
                   description: A URL of a publicly-accessible webpage for this product.
                   type: string
@@ -22454,7 +22533,8 @@ paths:
         required: false
         schema:
           type: integer
-      - description: The ID of the product whose SKUs will be retrieved.
+      - description: The ID of the product whose SKUs will be retrieved. Must be a
+          product with type `good`.
         in: query
         name: product
         required: false
@@ -22595,6 +22675,7 @@ paths:
                   type: integer
                 product:
                   description: The ID of the product this SKU is associated with.
+                    Must be a product with type `good`.
                   type: string
               required:
               - currency
@@ -22776,8 +22857,8 @@ paths:
                   type: integer
                 product:
                   description: The ID of the product that this SKU should belong to.
-                    The product must exist and have the same set of attribute names
-                    as the SKU's current product.
+                    The product must exist, have the same set of attribute names as
+                    the SKU's current product, and be of type `good`.
                   type: string
         required: false
       responses:
@@ -22992,6 +23073,40 @@ paths:
                   items:
                     type: string
                   type: array
+                mandate:
+                  properties:
+                    acceptance:
+                      properties:
+                        date:
+                          type: integer
+                        ip:
+                          type: string
+                        status:
+                          enum:
+                          - accepted
+                          - pending
+                          - refused
+                          - revoked
+                          type: string
+                        user_agent:
+                          type: string
+                      required:
+                      - date
+                      - ip
+                      - status
+                      - user_agent
+                      title: mandate_acceptance_params
+                      type: object
+                    notification_method:
+                      enum:
+                      - email
+                      - manual
+                      - none
+                      type: string
+                    reference:
+                      type: string
+                  title: mandate_params
+                  type: object
                 metadata:
                   description: A set of key/value pairs that you can attach to a source
                     object. It can be useful for storing additional information about
@@ -23032,6 +23147,44 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/source"
+          description: Successful response.
+        default:
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error"
+          description: Error response.
+  "/v1/sources/{source}/mandate_notifications/{mandate_notification}":
+    get:
+      description: "<p>Retrieves a new Source MandateNotification.</p>"
+      operationId: SourceMandateNotificationRetrieve
+      parameters:
+      - description: Specifies which fields in the response should be expanded.
+        in: query
+        name: expand
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - description: The ID of the Source MandateNotification.
+        in: path
+        name: mandate_notification
+        required: true
+        schema:
+          type: string
+      - description: The ID of the Source that received a ManateNotification.
+        in: path
+        name: source
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/source_mandate_notification"
           description: Successful response.
         default:
           content:
@@ -23682,9 +23835,9 @@ paths:
                     the customer default source, and delete the old customer default
                     if one exists. If you want to add an additional source, instead
                     use the [card creation API](https://stripe.com/docs/api#create_card)
-                    to add the card and then the [customer update API](https://stripe.com/docs/api#update
-                    customer) to set it as the default. Whenever you attach a card
-                    to a customer, Stripe will automatically validate the card.
+                    to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer)
+                    to set it as the default. Whenever you attach a card to a customer,
+                    Stripe will automatically validate the card.
                 tax_percent:
                   description: A non-negative decimal (with at most four decimal places)
                     between 0 and 100. This represents the percentage of the subscription
@@ -23904,9 +24057,9 @@ paths:
                     the customer default source, and delete the old customer default
                     if one exists. If you want to add an additional source, instead
                     use the [card creation API](https://stripe.com/docs/api#create_card)
-                    to add the card and then the [customer update API](https://stripe.com/docs/api#update
-                    customer) to set it as the default. Whenever you attach a card
-                    to a customer, Stripe will automatically validate the card.
+                    to add the card and then the [customer update API](https://stripe.com/docs/api#update_customer)
+                    to set it as the default. Whenever you attach a card to a customer,
+                    Stripe will automatically validate the card.
                 tax_percent:
                   description: A non-negative decimal (with at most four decimal places)
                     between 0 and 100. This represents the percentage of the subscription


### PR DESCRIPTION
This PR updates the OpenAPI spec for the Stripe API in anticipation of a new Stripe API version with separate products and plans. By putting up this PR, we can more easily test upcoming Stripe language bindings against a new OpenAPI spec.

This should not be merged until the new API version has been released.