### PR TITLE
Include default_source attribute to customer

### DIFF
--- a/openapi/fixtures2.json
+++ b/openapi/fixtures2.json
@@ -366,6 +366,7 @@
       "account_balance": 0,
       "created": 1234567890,
       "currency": "usd",
+      "default_source": null,
       "id": "cus_Cox9sWuLoPAaA8",
       "invoice_prefix": "45986A7",
       "livemode": false,

--- a/openapi/fixtures2.yaml
+++ b/openapi/fixtures2.yaml
@@ -291,6 +291,7 @@ resources:
     account_balance: 0
     created: 1234567890
     currency: usd
+    default_source:
     id: cus_Cox9sWuLoPAaA8
     invoice_prefix: 45986A7
     livemode: false

--- a/openapi/fixtures3.json
+++ b/openapi/fixtures3.json
@@ -366,6 +366,7 @@
       "account_balance": 0,
       "created": 1234567890,
       "currency": "usd",
+      "default_source": null,
       "id": "cus_Cox9sWuLoPAaA8",
       "invoice_prefix": "45986A7",
       "livemode": false,

--- a/openapi/fixtures3.yaml
+++ b/openapi/fixtures3.yaml
@@ -291,6 +291,7 @@ resources:
     account_balance: 0
     created: 1234567890
     currency: usd
+    default_source:
     id: cus_Cox9sWuLoPAaA8
     invoice_prefix: 45986A7
     livemode: false


### PR DESCRIPTION
Issue: https://github.com/stripe/stripe-mock/issues/78

I didn't know how to use a different OpenAPI set of data in stripe-mock to test this, so can't guarantee it's a fix. Hopefully it will be! Let me know if I can improve this. Thanks. 