### PR TITLE
Add "format: int64" to all integer balance fields

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -3481,7 +3481,8 @@
         "properties": {
           "account_balance": {
             "description": "This field has been renamed to `balance` and will be removed in a future API version.",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "address": {
             "anyOf": [
@@ -3494,6 +3495,7 @@
           },
           "balance": {
             "description": "Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized.",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -3888,6 +3890,7 @@
           },
           "ending_balance": {
             "description": "The customer's `balance` after the transaction was applied. A negative value decreases the amount due on the customer's next invoice. A positive value increases the amount due on the customer's next invoice.",
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -6198,6 +6201,7 @@
           },
           "ending_balance": {
             "description": "Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null.",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -6344,6 +6348,7 @@
           },
           "starting_balance": {
             "description": "Starting customer balance before the invoice is finalized. If the invoice has not been finalized yet, this will be the current customer balance.",
+            "format": "int64",
             "type": "integer"
           },
           "statement_descriptor": {
@@ -34087,6 +34092,7 @@
                 "properties": {
                   "account_balance": {
                     "description": "This field has been renamed to `balance` and will be removed in a future API version.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "address": {
@@ -34135,6 +34141,7 @@
                   },
                   "balance": {
                     "description": "An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "coupon": {
@@ -34594,6 +34601,7 @@
                 "properties": {
                   "account_balance": {
                     "description": "This field has been renamed to `balance` and will be removed in a future API version.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "address": {
@@ -34642,6 +34650,7 @@
                   },
                   "balance": {
                     "description": "An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "bank_account": {

--- a/openapi/spec3.sdk.json
+++ b/openapi/spec3.sdk.json
@@ -5054,6 +5054,7 @@
         "properties": {
           "account_balance": {
             "description": "This field has been renamed to `balance` and will be removed in a future API version.",
+            "format": "int64",
             "type": "integer"
           },
           "address": {
@@ -5067,6 +5068,7 @@
           },
           "balance": {
             "description": "Current balance, if any, being stored on the customer. If negative, the customer has credit to apply to their next invoice. If positive, the customer has an amount owed that will be added to their next invoice. The balance does not refer to any unpaid invoices; it solely takes into account amounts that have yet to be successfully applied to any invoice. This balance is only taken into account as invoices are finalized.",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -5581,6 +5583,7 @@
           },
           "ending_balance": {
             "description": "The customer's `balance` after the transaction was applied. A negative value decreases the amount due on the customer's next invoice. A positive value increases the amount due on the customer's next invoice.",
+            "format": "int64",
             "type": "integer"
           },
           "id": {
@@ -7902,6 +7905,7 @@
           },
           "ending_balance": {
             "description": "Ending customer balance after the invoice is finalized. Invoices are finalized approximately an hour after successful webhook delivery or when payment collection is attempted for the invoice. If the invoice has not been finalized yet, this will be null.",
+            "format": "int64",
             "nullable": true,
             "type": "integer"
           },
@@ -8048,6 +8052,7 @@
           },
           "starting_balance": {
             "description": "Starting customer balance before the invoice is finalized. If the invoice has not been finalized yet, this will be the current customer balance.",
+            "format": "int64",
             "type": "integer"
           },
           "statement_descriptor": {
@@ -35074,6 +35079,7 @@
                 "properties": {
                   "account_balance": {
                     "description": "This field has been renamed to `balance` and will be removed in a future API version.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "address": {
@@ -35122,6 +35128,7 @@
                   },
                   "balance": {
                     "description": "An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "coupon": {
@@ -35587,6 +35594,7 @@
                 "properties": {
                   "account_balance": {
                     "description": "This field has been renamed to `balance` and will be removed in a future API version.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "address": {
@@ -35635,6 +35643,7 @@
                   },
                   "balance": {
                     "description": "An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.",
+                    "format": "int64",
                     "type": "integer"
                   },
                   "coupon": {

--- a/openapi/spec3.sdk.yaml
+++ b/openapi/spec3.sdk.yaml
@@ -3805,6 +3805,7 @@ components:
         account_balance:
           description: This field has been renamed to `balance` and will be removed
             in a future API version.
+          format: int64
           type: integer
         address:
           anyOf:
@@ -3818,6 +3819,7 @@ components:
             The balance does not refer to any unpaid invoices; it solely takes into
             account amounts that have yet to be successfully applied to any invoice.
             This balance is only taken into account as invoices are finalized.
+          format: int64
           nullable: true
           type: integer
         created:
@@ -4203,6 +4205,7 @@ components:
           description: The customer's `balance` after the transaction was applied.
             A negative value decreases the amount due on the customer's next invoice.
             A positive value increases the amount due on the customer's next invoice.
+          format: int64
           type: integer
         id:
           description: Unique identifier for the object.
@@ -5938,6 +5941,7 @@ components:
             are finalized approximately an hour after successful webhook delivery
             or when payment collection is attempted for the invoice. If the invoice
             has not been finalized yet, this will be null.
+          format: int64
           nullable: true
           type: integer
         footer:
@@ -6071,6 +6075,7 @@ components:
           description: Starting customer balance before the invoice is finalized.
             If the invoice has not been finalized yet, this will be the current customer
             balance.
+          format: int64
           type: integer
         statement_descriptor:
           description: Extra information about an invoice for the customer's credit
@@ -27199,6 +27204,7 @@ paths:
                 account_balance:
                   description: This field has been renamed to `balance` and will be
                     removed in a future API version.
+                  format: int64
                   type: integer
                 address:
                   anyOf:
@@ -27235,6 +27241,7 @@ paths:
                     A negative amount represents a credit that decreases the amount
                     due on an invoice; a positive amount increases the amount due
                     on an invoice.
+                  format: int64
                   type: integer
                 coupon:
                   maxLength: 5000
@@ -27582,6 +27589,7 @@ paths:
                 account_balance:
                   description: This field has been renamed to `balance` and will be
                     removed in a future API version.
+                  format: int64
                   type: integer
                 address:
                   anyOf:
@@ -27618,6 +27626,7 @@ paths:
                     A negative amount represents a credit that decreases the amount
                     due on an invoice; a positive amount increases the amount due
                     on an invoice.
+                  format: int64
                   type: integer
                 coupon:
                   maxLength: 5000

--- a/openapi/spec3.yaml
+++ b/openapi/spec3.yaml
@@ -2755,6 +2755,7 @@ components:
         account_balance:
           description: This field has been renamed to `balance` and will be removed
             in a future API version.
+          format: int64
           type: integer
         address:
           anyOf:
@@ -2768,6 +2769,7 @@ components:
             The balance does not refer to any unpaid invoices; it solely takes into
             account amounts that have yet to be successfully applied to any invoice.
             This balance is only taken into account as invoices are finalized.
+          format: int64
           nullable: true
           type: integer
         created:
@@ -3064,6 +3066,7 @@ components:
           description: The customer's `balance` after the transaction was applied.
             A negative value decreases the amount due on the customer's next invoice.
             A positive value increases the amount due on the customer's next invoice.
+          format: int64
           type: integer
         id:
           description: Unique identifier for the object.
@@ -4856,6 +4859,7 @@ components:
             are finalized approximately an hour after successful webhook delivery
             or when payment collection is attempted for the invoice. If the invoice
             has not been finalized yet, this will be null.
+          format: int64
           nullable: true
           type: integer
         footer:
@@ -4989,6 +4993,7 @@ components:
           description: Starting customer balance before the invoice is finalized.
             If the invoice has not been finalized yet, this will be the current customer
             balance.
+          format: int64
           type: integer
         statement_descriptor:
           description: Extra information about an invoice for the customer's credit
@@ -26629,6 +26634,7 @@ paths:
                 account_balance:
                   description: This field has been renamed to `balance` and will be
                     removed in a future API version.
+                  format: int64
                   type: integer
                 address:
                   anyOf:
@@ -26665,6 +26671,7 @@ paths:
                     A negative amount represents a credit that decreases the amount
                     due on an invoice; a positive amount increases the amount due
                     on an invoice.
+                  format: int64
                   type: integer
                 coupon:
                   maxLength: 5000
@@ -26995,6 +27002,7 @@ paths:
                 account_balance:
                   description: This field has been renamed to `balance` and will be
                     removed in a future API version.
+                  format: int64
                   type: integer
                 address:
                   anyOf:
@@ -27031,6 +27039,7 @@ paths:
                     A negative amount represents a credit that decreases the amount
                     due on an invoice; a positive amount increases the amount due
                     on an invoice.
+                  format: int64
                   type: integer
                 bank_account:
                   anyOf:


### PR DESCRIPTION
Some openAPI implementations interpret undecorated `integer` types as unsigned `uint`s.  (This is the case in the Rust Stripe library at https://github.com/wyyerd/stripe-rs). 

Because balance related fields can be negative, this PR explicitly marks them as signed by denoting their format as int64. 

This has been applied to `account_balance`, `balance`, `starting_balance`, and `ending_balance`