### PR TITLE
Set nullable=true for fields that come as null for some invoices.

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -7431,7 +7431,8 @@
           },
           "subscription_proration_date": {
             "description": "Only set for upcoming invoices that preview prorations. The time used to calculate prorations.",
-            "type": "integer"
+            "type": "integer",
+            "nullable": true
           },
           "subtotal": {
             "description": "Total of all subscriptions, invoice items, and prorations on the invoice before any invoice level discount or tax is applied. Item discounts are already incorporated",
@@ -7443,7 +7444,8 @@
             "type": "integer"
           },
           "threshold_reason": {
-            "$ref": "#/components/schemas/invoice_threshold_reason"
+            "$ref": "#/components/schemas/invoice_threshold_reason",
+            "nullable": true
           },
           "total": {
             "description": "Total after discounts and taxes.",
@@ -12177,7 +12179,8 @@
           "invoice_item": {
             "description": "The ID of the [invoice item](https://stripe.com/docs/api/invoiceitems) associated with this line item if any.",
             "maxLength": 5000,
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "livemode": {
             "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
@@ -12228,7 +12231,8 @@
           "subscription_item": {
             "description": "The subscription item that generated this invoice item. Left empty if the line item is not an explicit result of a subscription.",
             "maxLength": 5000,
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "tax_amounts": {
             "description": "The amount of tax calculated per tax rate for this line item",
@@ -16946,7 +16950,8 @@
             "items": {
               "$ref": "#/components/schemas/price_tier"
             },
-            "type": "array"
+            "type": "array",
+            "nullable": true
           },
           "tiers_mode": {
             "description": "Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.",


### PR DESCRIPTION
Hi there! 
We've been using your openapi spec to build our integration with stripe. We found that a few fields are not marked as nullable, though they come as null (or just unset) when getting those resources through your endpoints. In some cases the documentation string of those fields indicate that they might be null, but they spec doesn't say so. 
This is less of a PR (I suppose you generate those files automatically), but I figured the diff would be easier to read in a PR format. Would you let me know if these fields should indeed be nullable? We're just getting started, so I expect we'll find a few more. Please let me know if this is the right channel or way of communicating this.
Thank you!
