### PR TITLE
Adding check to make sure token is returned

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -117,7 +117,7 @@ class Updater
   SOURCE_DIR = File.expand_path("~/stripe/pay-server/")
   TARGET_DIR = File.expand_path("../../", __FILE__)
   REPO_NAME = "openapi"
-  REPO_ORG = "stripe"
+  REPO_ORG = "ctrudeau-stripe"
 
   def initialize(dry_run: false, out: nil, utils: nil)
     self.dry_run = dry_run
@@ -125,14 +125,19 @@ class Updater
     self.utils = utils || SystemUtils.new
   end
 
-  def publish_new_version(user, repo_org, repo_name) 
-    github_token = utils.get_github_token(user)
+  def publish_new_version(github_token, repo_org, repo_name) 
     tag_name = utils.get_latest_github_release(repo_org, repo_name, github_token)
     github_release_response = utils.create_github_release(REPO_ORG, REPO_NAME, github_token, utils.increment_version(tag_name))
     github_release_response['html_url']
   end
 
   def run
+    github_token = utils.get_github_token(ENV['USER'])
+    if github_token == ""
+      utils.abort("Maybe you need to run `sc-2fa`?")
+      return # reachable in testing
+    end
+
     unless utils.dir_exists?(SOURCE_DIR)
       utils.abort("Source directory does not exist: #{SOURCE_DIR}")
       return # reachable in testing
@@ -198,7 +203,7 @@ class Updater
     else
       if committed
         out.puts "--> Publishing new version to github"
-        out.puts publish_new_version(ENV['USER'], REPO_ORG, REPO_NAME)
+        out.puts publish_new_version(github_token, REPO_ORG, REPO_NAME)
       else 
         out.puts "--> We did not commit so we did not create a release"
       end
@@ -227,6 +232,7 @@ else
     end
 
     def test_runs_successfully
+      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
       utils.expect(:dir_exists?, true,
         [Updater::SOURCE_DIR])
       utils.expect(:git_current_branch, "master",
@@ -271,8 +277,6 @@ else
 
       utils.expect(:git_push_origin_master, "")
 
-      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
-
       utils.expect(:get_latest_github_release, "v4",[Updater::REPO_ORG, Updater::REPO_NAME, "TOKEN"])
 
       utils.expect(:increment_version, "v5",["v4"])
@@ -284,6 +288,7 @@ else
     end
 
     def test_checks_source_and_aborts
+      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
       utils.expect(:dir_exists?, false,
         [Updater::SOURCE_DIR])
       utils.expect(:abort, nil,
@@ -293,6 +298,7 @@ else
     end
 
     def test_checks_source_on_master_and_aborts
+      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
       utils.expect(:dir_exists?, true,
         [Updater::SOURCE_DIR])
       utils.expect(:git_current_branch, "my-feature-branch",
@@ -304,6 +310,7 @@ else
     end
 
     def test_checks_target_unmodified_and_aborts
+      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
       utils.expect(:dir_exists?, true,
         [Updater::SOURCE_DIR])
       utils.expect(:git_current_branch, "master",
@@ -317,6 +324,7 @@ else
     end
 
     def test_checks_target_modified_after_copy_and_aborts
+      utils.expect(:get_github_token, "TOKEN",[ENV["USER"]])
       utils.expect(:dir_exists?, true,
         [Updater::SOURCE_DIR])
       utils.expect(:git_current_branch, "master",

--- a/bin/update
+++ b/bin/update
@@ -117,7 +117,7 @@ class Updater
   SOURCE_DIR = File.expand_path("~/stripe/pay-server/")
   TARGET_DIR = File.expand_path("../../", __FILE__)
   REPO_NAME = "openapi"
-  REPO_ORG = "ctrudeau-stripe"
+  REPO_ORG = "stripe"
 
   def initialize(dry_run: false, out: nil, utils: nil)
     self.dry_run = dry_run


### PR DESCRIPTION
When the user is not authenticated no token is returned. This will check to see the token is empty and throw an error to run auth instead. 

r? @richardm-stripe 