### PR TITLE
Update docs URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Run the test suite:
 
     make
 
-[expand]: https://stripe.com/docs/api/java#expanding_objects
+[expand]: https://stripe.com/docs/api/#expanding_objects
 [openapi]: https://www.openapis.org/
 
 <!--


### PR DESCRIPTION
r? @yejia-stripe 

### Summary

Updates docs URLs to no longer point to `/java`. This path doesn't exist anymore. This also doesn't need to be configured to a specific language.