### PR TITLE
Automate stripe-mock update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/checkout@v2
       with:
-        name: pakrym/stripe-mock
+        name: pakrym-stripe/stripe-mock
         ref: master
         path: stripe-mock
     - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
+name: Publish
+
 on:
+  workflow_dispatch: {}
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   publish-stripe-mock:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Publish
 
 on:
   workflow_dispatch: {}
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
   publish-stripe-mock:
@@ -25,5 +22,5 @@ jobs:
       uses: peter-evans/create-pull-request@v4
       with:
         path: stripe-mock
-        token: ${{ secrets.BOT_USER_PAT }}
+        token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
         push-to-fork: pakrym-stripe-bot/stripe-mock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        name: pakrym/stripe-mock
+        ref: master
+        path: stripe-mock
+    - run: |
+        rm -f ./stripe-mock/openapi/spec3.json
+        rm -f ./stripe-mock/openapi/fixtures3.json
+        cp openapi/spec3.json stripe-mock/openapi/spec3.json
+        cp openapi/fixtures3.json stripe-mock/openapi/fixtures3.json
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        path: stripe-mock
+        token: ${{ secrets.BOT_USER_PAT }}
+        push-to-fork: pakrym-stripe-bot/stripe-mock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  publish-stripe-mock:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Adds a workflow to update stripe-mock on openapi updates.

Uses my fork of stripe-mock for testing, I'll switch to the main repo after testing is done.