### PR TITLE
Move reviewer name into PR body

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,13 +40,14 @@ jobs:
       with:
         path: stripe-mock
         title: OpenAPI Update
-        body: Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
+        body: |
+          Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
+          r? @${{ github.actor }}
         branch: update-openapi
         token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
         push-to-fork: pakrym-stripe-bot/stripe-mock
         delete-branch: true
         commit-message: Update OpenAPI for ${{ github.sha }}
-        reviewers: ${{ github.actor }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Requesting an actual review requires admin rights in the repo.