### PR TITLE
Use GitHub Actions for creating pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,26 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+
+    # Fetch this repository
     - uses: actions/checkout@v2
+
+    # Fetch app installation token
+    - uses: tibdex/github-app-token@v1.5.2
+      id: gh-api-token
+      with:
+        app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+        private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+
+    # Fetch repositories to modify
     - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
+        token: ${{ steps.gh-api-token.outputs.token }}
         repository: stripe/stripe-mock
         path: stripe-mock
     - uses: actions/checkout@v3
       with:
-        token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
+        token: ${{ steps.gh-api-token.outputs.token }}
         repository: stripe/stripe-cli
         path: stripe-cli
 
@@ -27,6 +38,7 @@ jobs:
         rm -f ./api/openapi-spec/spec3.sdk.json 
         cp ../openapi/spec3.sdk.json ./api/openapi-spec/spec3.sdk.json 
         go generate ./...
+
       working-directory: ./stripe-cli
 
     - run: |
@@ -35,6 +47,7 @@ jobs:
         cp openapi/spec3.json stripe-mock/openapi/spec3.json
         cp openapi/fixtures3.json stripe-mock/openapi/fixtures3.json
 
+    # Create pull request on stripe-mock
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
@@ -42,21 +55,32 @@ jobs:
         title: OpenAPI Update
         body: |
           Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
+
           r? @${{ github.actor }}
-        branch: update-openapi
-        token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
-        push-to-fork: pakrym-stripe-bot/stripe-mock
+
+          [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+        branch: update-openapi-${{ github.sha }}
+        token: ${{ steps.gh-api-token.outputs.token }}
         delete-branch: true
         commit-message: Update OpenAPI for ${{ github.sha }}
+        committer: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
+        author: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
 
+    # Create pull request on openapi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
         path: stripe-cli
         title: OpenAPI Update
-        body: Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
-        branch: update-openapi
-        token: ${{ secrets.BOT_USER_PERSONAL_ACCESS_TOKEN }}
-        push-to-fork: pakrym-stripe-bot/stripe-cli
+        body: |
+          Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
+
+          r? @${{ github.actor }}
+
+          [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+        branch: update-openapi-${{ github.sha }}
+        token: ${{ steps.gh-api-token.outputs.token }}
         delete-branch: true
         commit-message: Update OpenAPI for ${{ github.sha }}
+        committer: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
+        author: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           r? @${{ github.actor }}
 
           [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
-        branch: update-openapi-${{ github.sha }}
+        branch: update-openapi
         token: ${{ steps.gh-api-token.outputs.token }}
         delete-branch: true
         commit-message: Update OpenAPI for ${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
           r? @${{ github.actor }}
 
           [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
-        branch: update-openapi-${{ github.sha }}
+        branch: update-openapi
         token: ${{ steps.gh-api-token.outputs.token }}
         delete-branch: true
         commit-message: Update OpenAPI for ${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,7 @@ jobs:
         rm -f ./api/openapi-spec/spec3.sdk.json 
         cp ../openapi/spec3.sdk.json ./api/openapi-spec/spec3.sdk.json 
         go generate ./...
-
       working-directory: ./stripe-cli
-
     - run: |
         rm -f ./stripe-mock/openapi/spec3.json
         rm -f ./stripe-mock/openapi/fixtures3.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
         body: |
           Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
 
-          r? @${{ github.actor }}
+          This pull request was initiated by @${{ github.actor }}
 
           [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
         branch: update-openapi


### PR DESCRIPTION
Migrates the workflow to use GitHub Actions instead of a separate service account.

We also set the committer & author to the bot, instead of a human, so that it's clear what the commit came from. But perhaps we want the committer to be the `${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>` instead, since it was sorta initiated by them?

In the pull request body, I've included a link to the workflow, so we also know where the pull requests came from.

I've also made the bodies consistent, I'm happy to remove the `r? @username` from the second body?

I tested this here: https://github.com/qaisjp/stripe-mock/pull/1. We can see other GitHub Actions workflows being executed in this pull request.

It looks like this:

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/923242/168395472-2ad3cec1-9c92-473f-8c38-8e3aef7ee214.png">

PTAL? @pakrym-stripe 