### PR TITLE
Allow CI workflow to be kicked off manually.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch: {}
   push:
     branches: [ master ]
   pull_request:


### PR DESCRIPTION
r? @pakrym-stripe 

This is useful when something is wrong with the CI workflow and we want to test it.