### PR TITLE
fix: Update bin/update to also pull tags from origin.

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -98,11 +98,11 @@ class SystemUtils
   end
 
   def git_pull_origin_master
-    execute_subshell(%{git pull origin master})
+    execute_subshell('git pull origin master --tags')
   end
 
   def git_push_origin_master
-    execute_subshell(%{git push origin master})
+    execute_subshell('git push origin master')
   end
 
   def write_file(file, data)


### PR DESCRIPTION
r? @pakrym-stripe 

## Summary

Update the initial pull to also pull down tags, which are needed for `diff_spec`.