### PR TITLE
Suppress yarn logs

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -51,7 +51,7 @@ class SystemUtils
   end
 
   def describe_openapi_diff(codegen_dir, target_dir, current_version_number)
-    `(cd #{codegen_dir} && yarn build:diff --repo #{target_dir} --old #{current_version_number})`
+    `(cd #{codegen_dir} && yarn -s build:diff --repo #{target_dir} --old #{current_version_number})`
   end
 
   def merge_spec(codegen_dir, from, to)


### PR DESCRIPTION
A follow-up to https://github.com/stripe/openapi/pull/104 to suppress extra logs.