### PR TITLE
React to the openapi spec move in the stripe-mock repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,10 @@ jobs:
         go generate ./...
       working-directory: ./stripe-cli
     - run: |
-        rm -f ./stripe-mock/openapi/spec3.json
-        rm -f ./stripe-mock/openapi/fixtures3.json
-        cp openapi/spec3.json stripe-mock/openapi/spec3.json
-        cp openapi/fixtures3.json stripe-mock/openapi/fixtures3.json
+        rm -f ./stripe-mock/embedded/openapi/spec3.json
+        rm -f ./stripe-mock/embedded/openapi/fixtures3.json
+        cp openapi/spec3.json stripe-mock/embedded/openapi/spec3.json
+        cp openapi/fixtures3.json stripe-mock/embedded/openapi/fixtures3.json
 
     # Create pull request on stripe-mock
     - name: Create Pull Request


### PR DESCRIPTION
In a recent change the openapi spec was moved into subdirectory.