### PR TITLE
Only run publish job on pushes to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish  
   
 on:  
-  push: {}  
-  
+  push:
+    branches:
+      - master
+
 jobs:
   publish:
     name: Publish spec to other repositories


### PR DESCRIPTION
The publish job is failing because it's running on every push. This PR updates the job to only run on commits to `master`.