### PR TITLE
Publish on tag creation and cancel in-progress publish jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v[0-9]+
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/stripe/openapi/pull/125 that causes the publish workflow to be triggered before the new version is published, so generated PRs in the language repos don't reflect the latest tagged version.

This runs the publish workflow on both tag creation and pushes to master, cancelling any in-progress workflows.