### PR TITLE
Cancel any in-progress Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       - v[0-9]+
   
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.ref` is different for tags - update the concurrency rule to cancel any run of the Publish workflow.