### PR TITLE
Use repo path instead of name in methods

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,13 +95,13 @@ jobs:
       with:
         pr_url: "${{ steps.cpr.outputs.pull-request-url }}"
         github_token: ${{ steps.gh-api-token.outputs.token }}
-        repo: "./stripe-mock"
+        repo: stripe/stripe-mock
 
     - uses: ./actions/approve
       name: Approve stripe-mock PR
       with:
         pr_url_or_branch: ${{ steps.cpr.outputs.pull-request-url }}
-        repo: ./stripe-mock
+        repo: stripe/stripe-mock
         github_app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APPROVER_APP_ID }}
         github_app_private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_APPROVER_PRIVATE_KEY }}
 

--- a/actions/approve/action.yml
+++ b/actions/approve/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'The pull request url or a branch name'
     required: true
   repo:
-    description: 'repository path'
+    description: 'repository name'
     required: true
   github_app_id:
     description: 'GitHub Approver App ID'
@@ -27,11 +27,12 @@ runs:
     - run: |
         set -e -x -o pipefail
 
+        gh pr -R ${{ inputs.repo }} view ${{ inputs.pr_url_or_branch }}
+
         PR_STATUS=$(gh pr view --json reviewDecision -q ".reviewDecision" ${{ inputs.pr_url_or_branch }} )
         if [ "$PR_STATUS" == "REVIEW_REQUIRED" ]; then
-          gh pr review --approve ${{ inputs.pr_url_or_branch }}
+          gh pr -R ${{ inputs.repo }} review --approve ${{ inputs.pr_url_or_branch }}
         fi
-      working-directory: ${{ inputs.repo }}
       name: Auto-approve
       shell: bash
       env:

--- a/actions/enable-auto-merge/action.yml
+++ b/actions/enable-auto-merge/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
     default: 'SQUASH'
   repo:
-    description: 'repository path'
+    description: 'repository name'
     required: true
   github_token:
     description: 'GitHub auth token'
@@ -23,7 +23,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       continue-on-error: true
-      working-directory: ${{ inputs.repo }}
       run: |
         set -e -o pipefail
 
@@ -32,9 +31,9 @@ runs:
           exit 1
         fi
 
-        PR_ID=$(gh pr view ${{ inputs.pr_url }} --json id --jq ".id")
+        PR_ID=$(gh -R ${{ inputs.repo }} pr view ${{ inputs.pr_url }} --json id --jq ".id")
 
-        gh api graphql -f query='
+        gh -R ${{ inputs.repo }} api graphql -f query='
           mutation($pull: ID!) {
             enablePullRequestAutoMerge(input: {pullRequestId: $pull, mergeMethod: ${{ inputs.mode }}}) {
               pullRequest {

--- a/actions/enable-auto-merge/action.yml
+++ b/actions/enable-auto-merge/action.yml
@@ -33,7 +33,7 @@ runs:
 
         PR_ID=$(gh -R ${{ inputs.repo }} pr view ${{ inputs.pr_url }} --json id --jq ".id")
 
-        gh ${{ inputs.repo }} api graphql -f query='
+        gh api graphql -f query='
           mutation($pull: ID!) {
             enablePullRequestAutoMerge(input: {pullRequestId: $pull, mergeMethod: ${{ inputs.mode }}}) {
               pullRequest {

--- a/actions/enable-auto-merge/action.yml
+++ b/actions/enable-auto-merge/action.yml
@@ -33,7 +33,7 @@ runs:
 
         PR_ID=$(gh -R ${{ inputs.repo }} pr view ${{ inputs.pr_url }} --json id --jq ".id")
 
-        gh -R ${{ inputs.repo }} api graphql -f query='
+        gh ${{ inputs.repo }} api graphql -f query='
           mutation($pull: ID!) {
             enablePullRequestAutoMerge(input: {pullRequestId: $pull, mergeMethod: ${{ inputs.mode }}}) {
               pullRequest {


### PR DESCRIPTION
gh cli behavior of resolving repo name from directory is funky and seems to use `upstream` sometimes instead of `origin`. 