### PR TITLE
Temporarily disable CLI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,23 +55,24 @@ jobs:
         repository: stripe/stripe-cli
         path: stripe-cli
 
-    - run: |
-        rm -f ./api/openapi-spec/spec3.sdk.json 
-        cp ../openapi/spec3.sdk.json ./api/openapi-spec/spec3.sdk.json 
-        go generate ./...
-      working-directory: ./stripe-cli
-    - run: |
-        rm -f ./stripe-mock/embedded/openapi/spec3.json
-        rm -f ./stripe-mock/embedded/openapi/spec3.beta.sdk.json
+    # Disabled until https://github.com/stripe/stripe-cli/pull/1124 is merged 
+    # - run: |
+    #     rm -f ./api/openapi-spec/spec3.sdk.json 
+    #     cp ../openapi/spec3.sdk.json ./api/openapi-spec/spec3.sdk.json 
+    #     go generate ./...
+    #   working-directory: ./stripe-cli
+    # - run: |
+    #     rm -f ./stripe-mock/embedded/openapi/spec3.json
+    #     rm -f ./stripe-mock/embedded/openapi/spec3.beta.sdk.json
 
-        rm -f ./stripe-mock/embedded/openapi/fixtures3.json
-        rm -f ./stripe-mock/embedded/openapi/fixtures3.beta.json
+    #     rm -f ./stripe-mock/embedded/openapi/fixtures3.json
+    #     rm -f ./stripe-mock/embedded/openapi/fixtures3.beta.json
 
-        cp openapi/spec3.json stripe-mock/embedded/openapi/spec3.json
-        cp openapi/spec3.beta.sdk.json stripe-mock/embedded/openapi/spec3.beta.sdk.json
+    #     cp openapi/spec3.json stripe-mock/embedded/openapi/spec3.json
+    #     cp openapi/spec3.beta.sdk.json stripe-mock/embedded/openapi/spec3.beta.sdk.json
 
-        cp openapi/fixtures3.json stripe-mock/embedded/openapi/fixtures3.json
-        cp openapi/fixtures3.beta.json stripe-mock/embedded/openapi/fixtures3.beta.json
+    #     cp openapi/fixtures3.json stripe-mock/embedded/openapi/fixtures3.json
+    #     cp openapi/fixtures3.beta.json stripe-mock/embedded/openapi/fixtures3.beta.json
 
     - name: Create Pull Request on stripe-mock
       id: cpr
@@ -105,23 +106,24 @@ jobs:
         github_app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APPROVER_APP_ID }}
         github_app_private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_APPROVER_PRIVATE_KEY }}
 
-    - name: Create pull request on stripe-cli
-      uses: peter-evans/create-pull-request@v4
-      with:
-        path: stripe-cli
-        title: OpenAPI Update
-        body: |
-          Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
+    # Disabled until https://github.com/stripe/stripe-cli/pull/1124 is merged
+    # - name: Create pull request on stripe-cli
+    #   uses: peter-evans/create-pull-request@v4
+    #   with:
+    #     path: stripe-cli
+    #     title: OpenAPI Update
+    #     body: |
+    #       Automated OpenAPI update for https://github.com/stripe/openapi/commit/${{ github.sha }}
 
-          This pull request was initiated by @${{ github.actor }}
+    #       This pull request was initiated by @${{ github.actor }}
 
-          [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
-        branch: update-openapi
-        token: ${{ steps.gh-api-token.outputs.token }}
-        delete-branch: true
-        commit-message: Update OpenAPI for ${{ github.sha }}
-        committer: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
-        author: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
+    #       [→ Debug this workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+    #     branch: update-openapi
+    #     token: ${{ steps.gh-api-token.outputs.token }}
+    #     delete-branch: true
+    #     commit-message: Update OpenAPI for ${{ github.sha }}
+    #     committer: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
+    #     author: "Stripe OpenAPI <105521251+stripe-openapi[bot]@users.noreply.github.com>"
 
     - uses: ./actions/notify-slack
       if: always()


### PR DESCRIPTION
Keep the publishing pipeline running while https://github.com/stripe/stripe-cli/pull/1124 is being resolved