### PR TITLE
Publish release using openapi app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,16 @@ jobs:
       run: |
         git fetch --tags --force
         echo "$(git tag -l --format='%(contents:body)' ${{ github.ref_name }})" > "${{ runner.temp }}/release_notes.md"
+
+    - name: Fetch app installation token
+      uses: tibdex/github-app-token@v1.5.2
+      id: gh-api-token
+      with:
+        app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+        private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         body_path: ${{ runner.temp }}/release_notes.md
+        token: ${{ steps.gh-api-token.outputs.token }}


### PR DESCRIPTION
Workflows don't trigger in response to actions performed by other workflows by default. (https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) 

So when we release using the default TOKEN the https://github.com/stripe/openapi/blob/master/.github/workflows/publish.yml#L5 action is not triggered. Switching to an app token should solve that. 