### PR TITLE
Update peter-evans/create-pull-request action to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Create Pull Request on stripe-mock
       id: cpr
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v6
       with:
         path: stripe-mock
         title: OpenAPI Update
@@ -135,7 +135,7 @@ jobs:
       working-directory: ./stripe-cli
       
     - name: Create pull request on stripe-cli
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v6
       with:
         path: stripe-cli
         title: OpenAPI Update


### PR DESCRIPTION
To get the fix for https://github.com/peter-evans/create-pull-request/issues/2790 that's failing our builds at https://github.com/stripe/openapi/actions/runs/8085788161/job/22094093903