### PR TITLE
Manually added scheduled_query_run file object

### DIFF
--- a/openapi/fixtures3.json
+++ b/openapi/fixtures3.json
@@ -2468,7 +2468,8 @@
       "object": "issuing.settlement",
       "settlement_service": "international",
       "transaction_count": 2,
-      "transaction_volume": 3656
+      "transaction_volume": 3656,
+      "status": "complete"
     },
     "issuing.token": {
       "card": "ic_1Pgag5B7WZ01zgkWephORn8N",

--- a/openapi/fixtures3.json
+++ b/openapi/fixtures3.json
@@ -3537,7 +3537,24 @@
     "scheduled_query_run": {
       "created": 1234567890,
       "data_load_time": 1234567890,
-      "file": null,
+      "file": {
+        "created": 1721948551,
+        "expires_at": null,
+        "filename": "path",
+        "id": "file_1Pgag7B7WZ01zgkWJbdoNCXR",
+        "links": {
+          "data": [],
+          "has_more": false,
+          "object": "list",
+          "url": "/v1/file_links?file=file_1Pgag7B7WZ01zgkWJbdoNCXR"
+        },
+        "object": "file",
+        "purpose": "sigma_scheduled_query",
+        "size": 500,
+        "title": null,
+        "type": "csv",
+        "url": "https://sangeekp-15t6ai--upload-mydev.dev.stripe.me/v1/files/file_1Pgag7B7WZ01zgkWJbdoNCXR/contents"
+      },
       "id": "sqr_1Pgc7AB7WZ01zgkWvpIic1Di",
       "livemode": false,
       "object": "scheduled_query_run",

--- a/openapi/fixtures3.yaml
+++ b/openapi/fixtures3.yaml
@@ -3047,7 +3047,22 @@ resources:
   scheduled_query_run:
     created: 1234567890
     data_load_time: 1234567890
-    file: null
+    file:
+      created: 1721948551
+      expires_at:
+      filename: path
+      id: file_1Pgag7B7WZ01zgkWJbdoNCXR
+      links:
+        data: []
+        has_more: false
+        object: list
+        url: /v1/file_links?file=file_1Pgag7B7WZ01zgkWJbdoNCXR
+      object: file
+      purpose: sigma_scheduled_query
+      size: 500
+      title: null
+      type: csv
+      url: https://sangeekp-15t6ai--upload-mydev.dev.stripe.me/v1/files/file_1Pgag7B7WZ01zgkWJbdoNCXR/contents
     id: sqr_1Pgc7AB7WZ01zgkWvpIic1Di
     livemode: false
     object: scheduled_query_run

--- a/openapi/fixtures3.yaml
+++ b/openapi/fixtures3.yaml
@@ -2136,6 +2136,7 @@ resources:
     settlement_service: international
     transaction_count: 2
     transaction_volume: 3656
+    status: complete
   issuing.token:
     card: ic_1Pgag5B7WZ01zgkWephORn8N
     created: 1234567890


### PR DESCRIPTION
### Why?
A recent update to the fixture files upstream cleared the `scheduled_query_run` `file` object which is required for our SDK tests to complete successfully (by way of stripe-mock).  This is a manual update to unblock the tests before the next openapi release.  The content is identical to what will be in that release for this specific fixture.

### What?
- added the `file` object from git hustory to the `scheduled_query_run` object in `fixtures3.json` and `fixtures3.yaml`