### PR TITLE
mention SDKs runner on build failures

### DIFF
--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -21,10 +21,11 @@ runs:
       uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: 'developer-sdks-team-bots'
+        # cc's @developer-sdks-run
         slack-message: >
           ❗ ${{ inputs.action }} *failed* (${{ job.status }})!
           <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Job> |
-          <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit>
+          <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit> cc: <@S03C9B2JDDY>
       env:
         SLACK_BOT_TOKEN: ${{ inputs.bot_token }}
       if: >


### PR DESCRIPTION
In order to better surface build failures before our users notice them, it's useful for the runner to get pinged when a build fails (rather than hoping they look at the channel)