### PR TITLE
Updated go version to match update in stripe-cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,7 +118,7 @@ jobs:
     # Set up GO
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.22
 
     - name: Checkout stripe-cli
       uses: actions/checkout@v3


### PR DESCRIPTION
Our [CI publish](https://github.com/stripe/openapi/actions/runs/12919429000/job/36029923560) started failing when stripe-cli updated the go version to 1.22. 

This PR updates our CI pipeline version of go to 1.22 in order to compile stripe-cli properly.