### PR TITLE
Add option to pass a spec version for OpenAPI to test with and beta

### DIFF
--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -6,11 +6,17 @@ inputs:
     description: 'Base branch'
     required: true
     default: "${{ github.base_ref || github.ref_name }}"
+  beta:
+    description: 'Explicitly use beta'
+    required: false
   fixtures:
     description: 'Path to custom fixtures file'
     required: false
   spec_path:
-    description: 'Path to OpenAPI specification'
+    description: 'Path to OpenAPI specification. Pass `openapi_version` OR `spec_path` OR neither, never both'
+    required: false
+  openapi_version:
+    description: 'Use the OpenAPI specification at a specific version. Pass `openapi_version` OR `spec_path` OR neither, never both'
     required: false
 
 runs:
@@ -20,20 +26,51 @@ runs:
       shell: bash
       run: |
         BETA_ARG=""
+        OPENAPI_VERSION=""
         FIXTURES_ARG=""
         SPEC_PATH_ARG=""
+        CURL_OPTS=(--retry 3 \
+            --retry-all-errors \
+            --fail \
+            --verbose \
+            --no-progress-meter \
+            --show-error)
 
-        if [ "${{ contains(inputs.base, 'b') }}" == "true" ]; then
+        CURRENT_OPENAPI_SPEC=$(realpath latest.json)
+        CURRENT_FIXTURES_JSON=${CURRENT_OPENAPI_SPEC%/*}/fixtures.json
+
+        SPEC_NAME="spec3.sdk.json"
+        FIXTURES_NAME="fixtures3.json"
+
+        if [ "${{ inputs.beta }}" == "true" ] || [ "${{ contains(inputs.base, 'b') }}" == "true" ]; then
+          echo "Running stripe-mock with beta flag"
           BETA_ARG="-beta"
+          SPEC_NAME="spec3.beta.sdk.json"
+          FIXTURES_NAME="fixtures3.beta.json"
+        fi
+
+        if [ -n "${{ inputs.openapi_version }}" ]; then
+          if [ -n "${{ inputs.spec_path }}" ]; then
+            echo "Error: Pass either an OpenAPI version or a spec path, not both"
+            exit 1
+          fi
+
+          echo "Pulling specs for ${{ inputs.openapi_version }}"
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/{{ inputs.openapi_version }}/openapi/$SPEC_NAME -o $CURRENT_OPENAPI_SPEC
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/{{ inputs.openapi_version }}/openapi/$FIXTURES_NAME -o $CURRENT_FIXTURES_JSON
+        fi
+        elif [ -n "${{ inputs.spec_path }}" ]; then
+          echo "Spec path provided, using spec at ${{ inputs.spec_path }}"
+          CURRENT_OPENAPI_SPEC="${{ inputs.spec_path }}"
         fi
 
         if [ -n "${{ inputs.fixtures }}" ]; then
-          FIXTURES_ARG="-fixtures ${{ inputs.fixtures }}"
+          echo "Fixtures path provided, using fixtures at ${{ inputs.fixtures }}"
+          CURRENT_FIXTURES_JSON="${{ inputs.fixtures }}"
         fi
 
-        if [ -n "${{ inputs.spec_path }}" ]; then
-          SPEC_PATH_ARG="-spec ${{ inputs.spec_path }}"
-        fi
+        SPEC_PATH_ARG="-spec $CURRENT_OPENAPI_SPEC"
+        FIXTURES_ARG="-fixtures $CURRENT_FIXTURES_JSON"
 
         docker run -d -p 12111-12112:12111-12112 \
           -v "${{ github.workspace }}:/workspace" \

--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -35,8 +35,8 @@ runs:
             --no-progress-meter \
             --show-error)
 
-        CURRENT_OPENAPI_SPEC=$(realpath latest.json)
-        CURRENT_FIXTURES_JSON=${CURRENT_OPENAPI_SPEC%/*}/fixtures.json
+        CURRENT_OPENAPI_SPEC=""
+        CURRENT_FIXTURES_JSON=""
 
         SPEC_NAME="spec3.sdk.json"
         FIXTURES_NAME="fixtures3.json"
@@ -59,10 +59,11 @@ runs:
             exit 1
           fi
 
+          CURRENT_OPENAPI_SPEC=$(pwd)/latest.json
+          CURRENT_FIXTURES_JSON=${CURRENT_OPENAPI_SPEC%/*}/fixtures.json
           echo "Pulling specs for ${{ inputs.openapi_version }}"
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/{{ inputs.openapi_version }}/openapi/$SPEC_NAME -o $CURRENT_OPENAPI_SPEC
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/{{ inputs.openapi_version }}/openapi/$FIXTURES_NAME -o $CURRENT_FIXTURES_JSON
-        fi
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/${{ inputs.openapi_version }}/openapi/$SPEC_NAME -o $CURRENT_OPENAPI_SPEC
+          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/${{ inputs.openapi_version }}/openapi/$FIXTURES_NAME -o $CURRENT_FIXTURES_JSON
         elif [ -n "${{ inputs.spec_path }}" ]; then
           echo "Spec path provided, using spec at ${{ inputs.spec_path }}"
           CURRENT_OPENAPI_SPEC="${{ inputs.spec_path }}"
@@ -73,8 +74,8 @@ runs:
           CURRENT_FIXTURES_JSON="${{ inputs.fixtures }}"
         fi
 
-        SPEC_PATH_ARG="-spec $CURRENT_OPENAPI_SPEC"
-        FIXTURES_ARG="-fixtures $CURRENT_FIXTURES_JSON"
+        SPEC_PATH_ARG=${CURRENT_OPENAPI_SPEC:+-spec $CURRENT_OPENAPI_SPEC}
+        FIXTURES_ARG=${CURRENT_FIXTURES_JSON:+-fixtures $CURRENT_FIXTURES_JSON}
 
         docker run -d -p 12111-12112:12111-12112 \
           -v "${{ github.workspace }}:/workspace" \

--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -26,7 +26,6 @@ runs:
       shell: bash
       run: |
         BETA_ARG=""
-        OPENAPI_VERSION=""
         FIXTURES_ARG=""
         SPEC_PATH_ARG=""
         CURL_OPTS=(--retry 3 \
@@ -52,6 +51,11 @@ runs:
         if [ -n "${{ inputs.openapi_version }}" ]; then
           if [ -n "${{ inputs.spec_path }}" ]; then
             echo "Error: Pass either an OpenAPI version or a spec path, not both"
+            exit 1
+          fi
+
+          if ! [[ "${{ inputs.openapi_version }}" =~ ^v[0-9]+$ ]]; then
+            echo "Error: Invalid OpenAPI version format. It should be in the format 'v<number>', e.g., 'v1', 'v2', etc."
             exit 1
           fi
 


### PR DESCRIPTION
## Why?

This adds an argument to this GH action to possible to provide an OpenAPI version as input and have the script pull the relevant SDK spec/fixtures for that api version.

This creates a much simpler flow for us when we have a version we know we need -- we do not need to pull the spec in the repos themselves. The codegen stripe-mock setup will still be a little more complicated, but it should make the language repos much simpler.

## What?

This adds 2 inputs to the script: `beta` and `openapi_version`.

I made the following calls, lmk if they make sense:
* You can only pass one of `openapi_version` or `spec_path`. I decided this since it requires the user to be very explicit about what they expect.
* If you provide both an `openapi_version` and `fixtures`, it will pull the spec version but use the provided fixtures (in case they are patched to update an item, for example).
* I added a `beta` arg for an option to explicitly tell the action to use beta. (This is useful for the `-next` use-case).
* If none of the spec, openapi version, or fixtures are provided, use the old defaults, the non-SDK superset spec and fixtures shipped with stripe-mock.

Let me know if you don't think any of these are the right move, or if this isn't worth doing!