### PR TITLE
Add additional sleep time after docker run for stripe-mock action

### DIFF
--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -79,4 +79,4 @@ runs:
 
         docker run -d -p 12111-12112:12111-12112 \
           -v "${{ github.workspace }}:/workspace" \
-          stripe/stripe-mock $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG && sleep 5
+          stripe/stripe-mock $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG && sleep 7


### PR DESCRIPTION
Tested with the openapi_version changes (https://github.com/stripe/openapi/pull/167/files), and the stripe-mock server didn't finish spinning up in time. This is a generous addition that should make sure we don't run into issues anytime soon.

(tested on https://github.com/stripe/stripe-dotnet/pull/3125/files, it used to fail due to not finding stripe-mock and now still failing but due to hitting the bad version of stripe-mock)