### PR TITLE
Pull private preview specs during OAS sync

### DIFF
--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -60,6 +60,16 @@ jobs:
           curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public_preview/sdk.yaml" \
             -o ./preview/openapi.spec3.sdk.yaml
 
+      - name: Download private preview JSON specs
+        run: |
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/private_preview/sdk.json" \
+            -o ./preview/openapi.private_preview.spec3.sdk.json
+
+      - name: Download private preview YAML specs
+        run: |
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/private_preview/sdk.yaml" \
+            -o ./preview/openapi.private_preview.spec3.sdk.yaml
+
       - name: Check for changes
         id: changes
         run: |


### PR DESCRIPTION
Include private preview specs during monthly sync of the Unified OAS.