### PR TITLE
ci: declare contents:read on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   # Trigger generated code updates only after a release was created
   # Generated code pipeline relies on latest release to pick up the spec


### PR DESCRIPTION
Pins `.github/workflows/publish.yml` to `permissions: contents: read` at the workflow level. The workflow already does the right thing operationally: every privileged action (the cross-repo dispatch, the `peter-evans/create-pull-request` against `stripe/stripe-mock`, the auto-merge enable, the approval) goes through an installation token minted via `tibdex/github-app-token`, not through `GITHUB_TOKEN`. The default token here is only used by the implicit `actions/checkout` step on the `stripe/openapi` repo itself, which is a read operation.

Declaring this in the file makes that observation enforceable rather than incidental. CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the canonical case for caring: a tampered third-party action exfiltrated `GITHUB_TOKEN` via workflow logs and the blast radius matched the issued scope. Capping `GITHUB_TOKEN` to `contents: read` keeps the runtime authority of the whole workflow chain at the minimum it actually needs, irrespective of repo or org default, with drift protection and Scorecard Token-Permissions credit attached.

YAML validated locally with `yaml.safe_load`.
