### PR TITLE
update slack group that gets pinged on failure

### DIFF
--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -1,31 +1,31 @@
-name: 'Notify Slack'
-description: 'Sends a slack notification when workflow succeeds or fails'
+name: "Notify Slack"
+description: "Sends a slack notification when workflow succeeds or fails"
 inputs:
   action:
-    description: 'What is the operation being performed'
+    description: "What is the operation being performed"
     required: true
   send_on_success:
-    description: 'Whether to send notification on success'
+    description: "Whether to send notification on success"
     required: true
   send_on_cancelled:
-    description: 'Whether to send notification on cancelled'
+    description: "Whether to send notification on cancelled"
     required: true
   bot_token:
-    description: 'Slack bot token'
+    description: "Slack bot token"
     required: true
-    
+
 runs:
   using: "composite"
   steps:
     - name: Post to a Slack channel
       uses: slackapi/slack-github-action@v1.23.0
       with:
-        channel-id: 'developer-sdks-team-bots'
-        # cc's @developer-sdks-run
+        channel-id: "developer-sdks-team-bots"
+        # cc's @developer-sdks-release-captain
         slack-message: >
           ❗ ${{ inputs.action }} *failed* (${{ job.status }})!
           <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Job> |
-          <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit> cc: <!subteam^S03C9B2JDDY>
+          <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|Commit> cc: <!subteam^S0AT18R76MA>
       env:
         SLACK_BOT_TOKEN: ${{ inputs.bot_token }}
       if: >
@@ -35,7 +35,7 @@ runs:
     - name: Post to a Slack channel
       uses: slackapi/slack-github-action@v1.23.0
       with:
-        channel-id: 'developer-sdks-team-bots'
+        channel-id: "developer-sdks-team-bots"
         slack-message: >
           ✅ ${{ inputs.action }} *succeeded*!
           <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Job> |


### PR DESCRIPTION
We ping an internal slack group when a GHA job fails. We've recently reorganized our slack groups, so we're updating the ID

(also, prettier ran)