### PR TITLE
pre-pull the stripe-mock docker image and retry the download if it fails

### DIFF
--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -22,6 +22,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Pull stripe-mock Docker image
+      shell: bash
+      run: |
+        for i in 1 2 3 4 5; do
+          if docker pull stripe/stripe-mock; then
+            exit 0
+          fi
+          echo "docker pull failed (attempt $i/5), retrying in 5s..."
+          sleep 5
+        done
+        echo "docker pull failed after 5 attempts"
+        exit 1
     - name: Start stripe-mock
       shell: bash
       run: |


### PR DESCRIPTION
The process of pulling from docker hub is fairly flaky, regularly causing jobs to fail ([like this one](https://github.com/stripe/stripe-dotnet/actions/runs/27308582239/job/80672802596)) only to work on retry.

Rather than implicitly pulling the stripe-mock image when needed as part of `docker-run`, we'll pre-pull it inside a retry loop in the hopes that we're a little more resistant to transient failures.