### PR TITLE
Stripe mock windows fix

### DIFF
--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -81,7 +81,7 @@ runs:
           MOCK_VERSION=$(curl "${CURL_OPTS[@]}" -s -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/stripe/stripe-mock/releases/latest | jq -r '.tag_name' | sed 's/^v//')
           curl "${CURL_OPTS[@]}" -L "https://github.com/stripe/stripe-mock/releases/download/v${MOCK_VERSION}/stripe-mock_${MOCK_VERSION}_windows_amd64.zip" -o stripe-mock.zip
           unzip stripe-mock.zip -d stripe-mock
-          ./stripe-mock/stripe-mock.exe $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG &
+          ./stripe-mock/stripe-mock.exe -http-addr 127.0.0.1:12111 -https-addr 127.0.0.1:12112 $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG &
           sleep 5
         else
           for i in 1 2 3 4 5; do

--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -81,8 +81,13 @@ runs:
           MOCK_VERSION=$(curl "${CURL_OPTS[@]}" -s -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/stripe/stripe-mock/releases/latest | jq -r '.tag_name' | sed 's/^v//')
           curl "${CURL_OPTS[@]}" -L "https://github.com/stripe/stripe-mock/releases/download/v${MOCK_VERSION}/stripe-mock_${MOCK_VERSION}_windows_amd64.zip" -o stripe-mock.zip
           unzip stripe-mock.zip -d stripe-mock
-          ./stripe-mock/stripe-mock.exe -http-addr 127.0.0.1:12111 -https-addr 127.0.0.1:12112 $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG &
+          nohup ./stripe-mock/stripe-mock.exe -http-addr 127.0.0.1:12111 -https-addr 127.0.0.1:12112 $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG > stripe-mock.log 2>&1 &
           sleep 5
+          if ! curl -s -o /dev/null http://127.0.0.1:12111; then
+            echo "stripe-mock failed to start. Log output:"
+            cat stripe-mock.log
+            exit 1
+          fi
         else
           for i in 1 2 3 4 5; do
             if docker pull stripe/stripe-mock; then

--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -83,9 +83,9 @@ runs:
           unzip stripe-mock.zip -d stripe-mock
           nohup ./stripe-mock/stripe-mock.exe -http-addr 127.0.0.1:12111 -https-addr 127.0.0.1:12112 $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG > stripe-mock.log 2>&1 &
           sleep 5
+          cat stripe-mock.log
           if ! curl -s -o /dev/null http://127.0.0.1:12111; then
-            echo "stripe-mock failed to start. Log output:"
-            cat stripe-mock.log
+            echo "stripe-mock failed to start!"
             exit 1
           fi
         else


### PR DESCRIPTION
Stripe mock was getting cleaned up on windows, so by the time tests started, it was no longer reachable. This fixes that by calling `nohup`, which keeps the process alive. It also double checks starting worked correctly.