### PR TITLE
move health check out of windows path

### DIFF
--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -84,10 +84,6 @@ runs:
           nohup ./stripe-mock/stripe-mock.exe -http-addr 127.0.0.1:12111 -https-addr 127.0.0.1:12112 $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG > stripe-mock.log 2>&1 &
           sleep 5
           cat stripe-mock.log
-          if ! curl -s -o /dev/null http://127.0.0.1:12111; then
-            echo "stripe-mock failed to start!"
-            exit 1
-          fi
         else
           for i in 1 2 3 4 5; do
             if docker pull stripe/stripe-mock; then
@@ -103,5 +99,16 @@ runs:
 
           docker run -d -p 12111-12112:12111-12112 \
             -v "${{ github.workspace }}:/workspace" \
-            stripe/stripe-mock $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG && sleep 7
+            stripe/stripe-mock $BETA_ARG $FIXTURES_ARG $SPEC_PATH_ARG
+          sleep 7
+        fi
+
+        if ! curl -s -o /dev/null http://127.0.0.1:12111; then
+          echo "stripe-mock failed to start!"
+          if [ "${{ runner.os }}" != "Windows" ]; then
+            docker logs $(docker ps -lq)
+          else
+            cat stripe-mock.log
+          fi
+          exit 1
         fi


### PR DESCRIPTION
Recently, stripe-mock was failing to start (see https://github.com/stripe/stripe-mock/pull/1640) and causing CI issues where the port was unreachable.

<img width="681" height="258" alt="image" src="https://github.com/user-attachments/assets/6ab355e9-b6eb-4557-8c3d-ab15fb363ada" />

But, the stripe-mock setup step in those CI jobs was passing, since we weren't checking that stripe-mock was actually reachable after startup. So SDKs would eventually fail to start with varying levels of confusing error message.