### PR TITLE
Pin and modernize GitHub Actions references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,16 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: gh-api-token
       with:
-        app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
-        private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+        private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        # The token's only use is dispatching sdk-codegen's codegen workflow,
+        # which needs actions: write on that one repository.
+        owner: stripe
+        repositories: sdk-codegen
+        permission-actions: write
 
     - name: Trigger generated code update
       run: |
@@ -58,11 +63,17 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: gh-api-token
       with:
-        app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
-        private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+        private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        # The token checks out stripe-mock, pushes the update-openapi branch,
+        # and opens plus auto-merges the PR there. Nothing else.
+        owner: stripe
+        repositories: stripe-mock
+        permission-contents: write
+        permission-pull-requests: write
 
     # Fetch repositories to modify
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout openapi
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Fetch app installation token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -61,6 +63,8 @@ jobs:
     steps:
     - name: Checkout openapi
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Fetch app installation token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -81,6 +85,10 @@ jobs:
         token: ${{ steps.gh-api-token.outputs.token }}
         repository: stripe/stripe-mock
         path: stripe-mock
+        # create-pull-request installs its own credential from the token input
+        # below, and unsets any persisted one first, so nothing here needs the
+        # App token left behind in .git/config.
+        persist-credentials: false
 
     - run: |
         rm -f ./stripe-mock/embedded/openapi/spec3.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Create Pull Request on stripe-mock
       id: cpr
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         path: stripe-mock
         title: OpenAPI Update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,10 +39,12 @@ jobs:
         permission-actions: write
 
     - name: Trigger generated code update
+      env:
+        GH_API_TOKEN: ${{ steps.gh-api-token.outputs.token }}
       run: |
         curl --fail-with-body \
           -X POST \
-          -H 'Authorization: token ${{ steps.gh-api-token.outputs.token }}' \
+          -H "Authorization: token ${GH_API_TOKEN}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \
           https://api.github.com/repos/stripe/sdk-codegen/actions/workflows/codegen.yml/dispatches \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout openapi
-      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Fetch app installation token
       uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout openapi
-      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Fetch app installation token
       uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
@@ -65,7 +65,7 @@ jobs:
         private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
     # Fetch repositories to modify
-    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ steps.gh-api-token.outputs.token }}
         repository: stripe/stripe-mock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout openapi
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@v1.5.2
+      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
       id: gh-api-token
       with:
         app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
@@ -55,17 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout openapi
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@v1.5.2
+      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
       id: gh-api-token
       with:
         app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
         private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
     # Fetch repositories to modify
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       with:
         token: ${{ steps.gh-api-token.outputs.token }}
         repository: stripe/stripe-mock
@@ -86,7 +86,7 @@ jobs:
 
     - name: Create Pull Request on stripe-mock
       id: cpr
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:
         path: stripe-mock
         title: OpenAPI Update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
     - name: Release
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         body_path: ${{ runner.temp }}/release_notes.md
         token: ${{ steps.gh-api-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    # The push trigger is already restricted to v[0-9]+ tags, but
+    # workflow_dispatch is not, and GITHUB_REF_NAME is then a branch name.
+    # action-gh-release used to refuse that case ("GitHub Releases requires a
+    # tag"); `gh release create` would instead happily cut a new tag named after
+    # the branch, so the refusal has to be explicit now.
+    - name: Require a tag
+      run: |
+        if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+          echo "::error::Releases require a tag. ${GITHUB_REF_NAME} is a ${GITHUB_REF_TYPE}."
+          exit 1
+        fi
+
     - name: Extract tag message
       run: |
         git fetch --tags --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: Extract tag message
       run: |
         git fetch --tags --force
@@ -41,14 +41,14 @@ jobs:
         } >> "${{ runner.temp }}/release_notes.md"
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@v1.5.2
+      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
       id: gh-api-token
       with:
         app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
         private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       with:
         body_path: ${{ runner.temp }}/release_notes.md
         token: ${{ steps.gh-api-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Extract tag message
       run: |
         git fetch --tags --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,14 @@ on:
     tags:
       - v[0-9]+
 
+permissions: {}
+
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,14 @@ jobs:
         } >> "${{ runner.temp }}/release_notes.md"
 
     - name: Fetch app installation token
-      uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: gh-api-token
       with:
-        app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
-        private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+        private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+        # The token's only use is creating a release in this repository. Scope
+        # defaults to the current repository when owner and repositories are unset.
+        permission-contents: write
 
     - name: Release
       uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Extract tag message
       run: |
         git fetch --tags --force
-        echo "$(git tag -l --format='%(contents:body)' ${{ github.ref_name }})" > "${{ runner.temp }}/release_notes.md"
+        echo "$(git tag -l --format='%(contents:body)' "${GITHUB_REF_NAME}")" > "${{ runner.temp }}/release_notes.md"
 
     - name: Add OpenAPI spec versions to release notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Extract tag message
       run: |
         git fetch --tags --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,16 @@ jobs:
         permission-contents: write
 
     - name: Release
-      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-      with:
-        body_path: ${{ runner.temp }}/release_notes.md
-        token: ${{ steps.gh-api-token.outputs.token }}
+      env:
+        GH_TOKEN: ${{ steps.gh-api-token.outputs.token }}
+        GH_REPO: ${{ github.repository }}
+        NOTES_FILE: ${{ runner.temp }}/release_notes.md
+      # Mirrors action-gh-release's create-or-update behaviour: it overwrites
+      # the notes on an existing release rather than failing, which is what
+      # makes re-running this workflow on a tag safe.
+      run: |
+        if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+          gh release edit "${GITHUB_REF_NAME}" --notes-file "${NOTES_FILE}"
+        else
+          gh release create "${GITHUB_REF_NAME}" --notes-file "${NOTES_FILE}"
+        fi

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -16,11 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch app installation token
-        uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: gh-api-token
         with:
-          app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
-          private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
+          private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
+          # The token checks out this repository and pushes the synced spec
+          # artifacts back to it. Scope defaults to the current repository.
+          permission-contents: write
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
           private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.gh-api-token.outputs.token }}
 

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch app installation token
-        uses: tibdex/github-app-token@v1.5.2
+        uses: tibdex/github-app-token@586e1a624db6a5a4ac2c53daeeded60c5e3d50fe # v1.5.2
         id: gh-api-token
         with:
           app_id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
           private_key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ steps.gh-api-token.outputs.token }}
 

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -41,37 +41,49 @@ jobs:
 
       - name: Download latest (GA) JSON specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/ga/public.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/ga/public.json" \
             -o ./latest/openapi.spec3.json
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/ga/sdk.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/ga/sdk.json" \
             -o ./latest/openapi.spec3.sdk.json
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Download latest (GA) YAML specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/ga/public.yaml" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/ga/public.yaml" \
             -o ./latest/openapi.spec3.yaml
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/ga/sdk.yaml" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/ga/sdk.yaml" \
             -o ./latest/openapi.spec3.sdk.yaml
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Download preview JSON specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public_preview/sdk.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/public_preview/sdk.json" \
             -o ./preview/openapi.spec3.sdk.json
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Download preview YAML specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/public_preview/sdk.yaml" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/public_preview/sdk.yaml" \
             -o ./preview/openapi.spec3.sdk.yaml
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Download private preview JSON specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/private_preview/sdk.json" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/private_preview/sdk.json" \
             -o ./preview/openapi.private_preview.spec3.sdk.json
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Download private preview YAML specs
         run: |
-          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${{ inputs.version }}/private_preview/sdk.yaml" \
+          curl -fsSL "https://b.stripecdn.com/api-artifacts/assets/openapi/${INPUTS_VERSION}/private_preview/sdk.yaml" \
             -o ./preview/openapi.private_preview.spec3.sdk.yaml
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Check for changes
         id: changes
@@ -89,5 +101,7 @@ jobs:
           git config user.name "Stripe OpenAPI"
           git config user.email "105521251+stripe-openapi[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "Update OpenAPI for ${{ inputs.version }}"
+          git commit -m "Update OpenAPI for ${INPUTS_VERSION}"
           git push
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}

--- a/.github/workflows/sync-openapi-artifacts.yml
+++ b/.github/workflows/sync-openapi-artifacts.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This is the one checkout in the repo that keeps its persisted
+          # credential, because the last step is a plain `git push` that needs
+          # it. zizmor's artipacked finding is about the credential escaping via
+          # an uploaded artifact; this workflow uploads none, and the push is the
+          # final step, so there is nothing after it to leak through.
           token: ${{ steps.gh-api-token.outputs.token }}
 
       - name: Get current version

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,9 +14,8 @@ jobs:
         with:
           persist-credentials: false
       # Scans the whole repository by default, which is what we want here rather
-      # than just .github/workflows/: the composite actions under actions/ are
-      # consumed by all 7 SDK repos, so they are the highest-leverage workflow
-      # code in the fleet and the least visible.
+      # than just .github/workflows/: it covers the composite actions under
+      # actions/, which the SDK repos invoke on every CI run.
       - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           # Load-bearing, not a preference. Advanced Security mode runs zizmor with
@@ -27,7 +26,7 @@ jobs:
           # Mutually exclusive with advanced-security. Reports findings as inline
           # annotations on the pull request instead of in the security tab.
           annotations: true
-          # The threshold Stripe's own workflow scanning uses. Gating here rather than
+          # The threshold these findings were reported at. Gating here rather than
           # at zizmor's default keeps a newly added low or medium audit from turning
           # this repo red without anyone having changed a workflow.
           min-severity: high

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+on: [push, pull_request]
+name: Workflow security
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Scans the whole repository by default, which is what we want here rather
+      # than just .github/workflows/: the composite actions under actions/ are
+      # consumed by all 7 SDK repos, so they are the highest-leverage workflow
+      # code in the fleet and the least visible.
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Load-bearing, not a preference. Advanced Security mode runs zizmor with
+          # --format=sarif, where zizmor exits 0 even when it has findings, and the
+          # action propagates that exit code -- so leaving this on produces a check
+          # that can never fail. false selects --format=github, which exits nonzero.
+          advanced-security: false
+          # Mutually exclusive with advanced-security. Reports findings as inline
+          # annotations on the pull request instead of in the security tab.
+          annotations: true
+          # The threshold Stripe's own workflow scanning uses. Gating here rather than
+          # at zizmor's default keeps a newly added low or medium audit from turning
+          # this repo red without anyone having changed a workflow.
+          min-severity: high
+          # The action defaults to 'latest'. Pinning the action's commit does not pin
+          # the binary it downloads, and an unpinned binary can change what CI
+          # enforces with no review on our side.
+          version: 1.29.0

--- a/actions/approve/action.yml
+++ b/actions/approve/action.yml
@@ -18,12 +18,29 @@ runs:
   using: "composite"
   steps:
 
+    # create-github-app-token scopes by owner plus a list of bare repository
+    # names, while callers pass `repo` as owner/name for `gh -R`. Split it here
+    # rather than making every caller pass both halves.
+    - name: Resolve the target repository
+      id: target
+      shell: bash
+      env:
+        TARGET_REPO: ${{ inputs.repo }}
+      run: |
+        echo "owner=${TARGET_REPO%%/*}" >> "$GITHUB_OUTPUT"
+        echo "name=${TARGET_REPO#*/}" >> "$GITHUB_OUTPUT"
+
     - name: Fetch approver app installation token
-      uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1.9.0
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: gh-approver-api-token
       with:
-        app_id: ${{ inputs.github_app_id }}
-        private_key: ${{ inputs.github_app_private_key }}
+        app-id: ${{ inputs.github_app_id }}
+        private-key: ${{ inputs.github_app_private_key }}
+        # The token's only use is reading one PR's review state and approving
+        # it, on the single repository the caller names.
+        owner: ${{ steps.target.outputs.owner }}
+        repositories: ${{ steps.target.outputs.name }}
+        permission-pull-requests: write
     - run: |
         set -e -x -o pipefail
 

--- a/actions/approve/action.yml
+++ b/actions/approve/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
 
     - name: Fetch approver app installation token
-      uses: tibdex/github-app-token@v1
+      uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1.9.0
       id: gh-approver-api-token
       with:
         app_id: ${{ inputs.github_app_id }}

--- a/actions/approve/action.yml
+++ b/actions/approve/action.yml
@@ -44,11 +44,13 @@ runs:
     - run: |
         set -e -x -o pipefail
 
-        PR_STATUS=$(gh pr -R ${{ inputs.repo }} view --json reviewDecision -q ".reviewDecision" ${{ inputs.pr_url_or_branch }} )
+        PR_STATUS=$(gh pr -R "${INPUTS_REPO}" view --json reviewDecision -q ".reviewDecision" "${INPUTS_PR_URL_OR_BRANCH}")
         if [ "$PR_STATUS" == "REVIEW_REQUIRED" ]; then
-          gh pr -R ${{ inputs.repo }} review --approve ${{ inputs.pr_url_or_branch }}
+          gh pr -R "${INPUTS_REPO}" review --approve "${INPUTS_PR_URL_OR_BRANCH}"
         fi
       name: Auto-approve
       shell: bash
       env:
         GITHUB_TOKEN: ${{ steps.gh-approver-api-token.outputs.token }}
+        INPUTS_REPO: ${{ inputs.repo }}
+        INPUTS_PR_URL_OR_BRANCH: ${{ inputs.pr_url_or_branch }}

--- a/actions/enable-auto-merge/action.yml
+++ b/actions/enable-auto-merge/action.yml
@@ -22,20 +22,28 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUTS_PR_URL: ${{ inputs.pr_url }}
+        INPUTS_REPO: ${{ inputs.repo }}
+        INPUTS_MODE: ${{ inputs.mode }}
       continue-on-error: true
       run: |
         set -e -o pipefail
 
-        if [ "${{ inputs.pr_url }}" == "" ]; then
+        if [ "${INPUTS_PR_URL}" == "" ]; then
           echo "PR URL is required"
           exit 1
         fi
 
-        PR_ID=$(gh -R ${{ inputs.repo }} pr view ${{ inputs.pr_url }} --json id --jq ".id")
+        PR_ID=$(gh -R "${INPUTS_REPO}" pr view "${INPUTS_PR_URL}" --json id --jq ".id")
 
+        # mode travels as a typed GraphQL variable rather than being pasted into
+        # the query text: the server validates it against the
+        # PullRequestMergeMethod enum, so it cannot carry query syntax at all.
+        # It also has to be a variable — the query is single-quoted, so the shell
+        # would not expand it inside there.
         gh api graphql -f query='
-          mutation($pull: ID!) {
-            enablePullRequestAutoMerge(input: {pullRequestId: $pull, mergeMethod: ${{ inputs.mode }}}) {
+          mutation($pull: ID!, $mode: PullRequestMergeMethod) {
+            enablePullRequestAutoMerge(input: {pullRequestId: $pull, mergeMethod: $mode}) {
               pullRequest {
                 id
                 number
@@ -44,4 +52,4 @@ runs:
                 }
               }
             }
-          }' -f pull=$PR_ID
+          }' -f pull="$PR_ID" -f mode="$INPUTS_MODE"

--- a/actions/notify-release/action.yml
+++ b/actions/notify-release/action.yml
@@ -8,8 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # $/ resolves to this repository at the running commit, so there is no ref to
-    # pin and no drift between this action and the sibling it invokes.
+    # $/ resolves to this repository at the running commit.
     # https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsstepsuses
     - uses: $/actions/notify-slack
       with:

--- a/actions/notify-release/action.yml
+++ b/actions/notify-release/action.yml
@@ -8,7 +8,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: stripe/openapi/actions/notify-slack@master
+    # A composite action cannot reach a sibling action by relative path, so this
+    # names its own repository. Pinned like any other reference; see the PR for
+    # why the target commit is master's tip rather than this branch's.
+    - uses: stripe/openapi/actions/notify-slack@325f3b157f7250f2a5d228b870d77bb63fc7e54c # v2407
       with:
         bot_token: ${{ inputs.bot_token }}
         action: Releasing ${{ github.repository }} ${{ github.ref_name }}

--- a/actions/notify-release/action.yml
+++ b/actions/notify-release/action.yml
@@ -8,10 +8,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # A composite action cannot reach a sibling action by relative path, so this
-    # names its own repository. Pinned like any other reference; see the PR for
-    # why the target commit is master's tip rather than this branch's.
-    - uses: stripe/openapi/actions/notify-slack@325f3b157f7250f2a5d228b870d77bb63fc7e54c # v2407
+    # $/ resolves to this repository at the running commit, so there is no ref to
+    # pin and no drift between this action and the sibling it invokes.
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsstepsuses
+    - uses: $/actions/notify-slack
       with:
         bot_token: ${{ inputs.bot_token }}
         action: Releasing ${{ github.repository }} ${{ github.ref_name }}

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Post to a Slack channel
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
       with:
         channel-id: "developer-sdks-team-bots"
         # cc's @developer-sdks-release-captain
@@ -33,7 +33,7 @@ runs:
         (job.status == 'cancelled' && inputs.send_on_cancelled == 'true')
 
     - name: Post to a Slack channel
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
       with:
         channel-id: "developer-sdks-team-bots"
         slack-message: >

--- a/actions/stripe-mock/action.yml
+++ b/actions/stripe-mock/action.yml
@@ -41,37 +41,37 @@ runs:
         SPEC_NAME="spec3.sdk.json"
         FIXTURES_NAME="fixtures3.json"
 
-        if [ "${{ inputs.beta }}" == "true" ] || [ "${{ contains(inputs.base, 'b') }}" == "true" ]; then
+        if [ "${INPUTS_BETA}" == "true" ] || [ "${{ contains(inputs.base, 'b') }}" == "true" ]; then
           echo "Running stripe-mock with beta flag"
           BETA_ARG="-beta"
           SPEC_NAME="spec3.beta.sdk.json"
           FIXTURES_NAME="fixtures3.beta.json"
         fi
 
-        if [ -n "${{ inputs.openapi_version }}" ]; then
-          if [ -n "${{ inputs.spec_path }}" ]; then
+        if [ -n "${INPUTS_OPENAPI_VERSION}" ]; then
+          if [ -n "${INPUTS_SPEC_PATH}" ]; then
             echo "Error: Pass either an OpenAPI version or a spec path, not both"
             exit 1
           fi
 
-          if ! [[ "${{ inputs.openapi_version }}" =~ ^v[0-9]+$ ]]; then
+          if ! [[ "${INPUTS_OPENAPI_VERSION}" =~ ^v[0-9]+$ ]]; then
             echo "Error: Invalid OpenAPI version format. It should be in the format 'v<number>', e.g., 'v1', 'v2', etc."
             exit 1
           fi
 
           CURRENT_OPENAPI_SPEC=$(pwd)/latest.json
           CURRENT_FIXTURES_JSON=${CURRENT_OPENAPI_SPEC%/*}/fixtures.json
-          echo "Pulling specs for ${{ inputs.openapi_version }}"
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/${{ inputs.openapi_version }}/openapi/$SPEC_NAME -o $CURRENT_OPENAPI_SPEC
-          curl "${CURL_OPTS[@]}" https://raw.githubusercontent.com/stripe/openapi/${{ inputs.openapi_version }}/openapi/$FIXTURES_NAME -o $CURRENT_FIXTURES_JSON
-        elif [ -n "${{ inputs.spec_path }}" ]; then
-          echo "Spec path provided, using spec at ${{ inputs.spec_path }}"
-          CURRENT_OPENAPI_SPEC="${{ inputs.spec_path }}"
+          echo "Pulling specs for ${INPUTS_OPENAPI_VERSION}"
+          curl "${CURL_OPTS[@]}" "https://raw.githubusercontent.com/stripe/openapi/${INPUTS_OPENAPI_VERSION}/openapi/$SPEC_NAME" -o "$CURRENT_OPENAPI_SPEC"
+          curl "${CURL_OPTS[@]}" "https://raw.githubusercontent.com/stripe/openapi/${INPUTS_OPENAPI_VERSION}/openapi/$FIXTURES_NAME" -o "$CURRENT_FIXTURES_JSON"
+        elif [ -n "${INPUTS_SPEC_PATH}" ]; then
+          echo "Spec path provided, using spec at ${INPUTS_SPEC_PATH}"
+          CURRENT_OPENAPI_SPEC="${INPUTS_SPEC_PATH}"
         fi
 
-        if [ -n "${{ inputs.fixtures }}" ]; then
-          echo "Fixtures path provided, using fixtures at ${{ inputs.fixtures }}"
-          CURRENT_FIXTURES_JSON="${{ inputs.fixtures }}"
+        if [ -n "${INPUTS_FIXTURES}" ]; then
+          echo "Fixtures path provided, using fixtures at ${INPUTS_FIXTURES}"
+          CURRENT_FIXTURES_JSON="${INPUTS_FIXTURES}"
         fi
 
         SPEC_PATH_ARG=${CURRENT_OPENAPI_SPEC:+-spec $CURRENT_OPENAPI_SPEC}
@@ -112,3 +112,8 @@ runs:
           fi
           exit 1
         fi
+      env:
+        INPUTS_BETA: ${{ inputs.beta }}
+        INPUTS_OPENAPI_VERSION: ${{ inputs.openapi_version }}
+        INPUTS_SPEC_PATH: ${{ inputs.spec_path }}
+        INPUTS_FIXTURES: ${{ inputs.fixtures }}


### PR DESCRIPTION
### Why?

Remediates 21 high-severity zizmor findings across `publish.yml`, `release.yml`, and `sync-openapi-artifacts.yml`.

This also upgrades the end-of-life actions the pins would otherwise freeze in place, and replaces the archived `tibdex/github-app-token`.

### What?

- migrages **`tibdex/github-app-token`to `actions/create-github-app-token@v3`**
- replaces **`softprops/action-gh-release` with`gh release` in a script step.
- **`release.yml` now refuses to run from a non-tag ref.** 
- upgrades **`peter-evans/create-pull-request` v6 → v8** and **`actions/checkout` → v7**.
- **The merge mode in `actions/enable-auto-merge` is now a typed GraphQL variable**, not text pasted into the query.
- **`notify-release` reaches its sibling `notify-slack` through `$/`**. `$/` resolves to this repository at the running commit.

Also fixed: `artipacked` (persisted checkout credentials, except where absolutely needed e.g. `sync-openapi-artifacts.yml`), `archived-uses`, `excessive-permissions` on `release.yml`, and the `github-app` findings introduced by the token swap.

**Verification.**

```
zizmor --min-severity=high .   ->  No findings to report
zizmor .                       ->  1 medium (the exception above), 0 low, 0 high
```

Every pin was checked against the tag its comment claims, and each resolves to a commit rather than a tag object.

### After merging

`tibdex/github-app-token@v1`/`@v1.5.2` and `softprops/action-gh-release@v1` become unused once this merges and can be dropped from the allowed actions.  `ruby/setup-ruby@v1` is already stale; nothing in the repo uses it.

### See Also

- Reported by zizmor as `unpinned-uses` and `template-injection`; this also clears `archived-uses`, `github-app`, `artipacked`, `excessive-permissions`, and `superfluous-actions`: https://docs.zizmor.sh/audits/

