### PR TITLE
Grant contents:read to approver token in actions/approve

### DIFF
--- a/actions/approve/action.yml
+++ b/actions/approve/action.yml
@@ -41,6 +41,10 @@ runs:
         owner: ${{ steps.target.outputs.owner }}
         repositories: ${{ steps.target.outputs.name }}
         permission-pull-requests: write
+        # Resolving a PR by branch name makes `gh pr view` read
+        # repository.defaultBranchRef, which requires contents read; without it
+        # the query fails with "Resource not accessible by integration".
+        permission-contents: read
     - run: |
         set -e -x -o pipefail
 


### PR DESCRIPTION
## Problem

Since #194 `Update OpenAPI v2` run that reaches the `Auto-approve` step fails, e.g. [sdk-codegen run 32993717255](https://github.com/stripe/sdk-codegen/actions/runs/32993717255):

```
GraphQL: Resource not accessible by integration (repository.defaultBranchRef)
+ PR_STATUS=
##[error]Process completed with exit code 1.
```

## Root cause

#194 migrated `actions/approve` from `tibdex/github-app-token@v1` (full installation permissions) to `actions/create-github-app-token`, scoping the token to `permission-pull-requests: write` only.

The `Auto-approve` step resolves the PR by **branch name**:

```bash
gh pr -R "${INPUTS_REPO}" view --json reviewDecision -q ".reviewDecision" "${INPUTS_PR_URL_OR_BRANCH}"
```

Looking a PR up by branch makes `gh`'s GraphQL query read `repository.defaultBranchRef` (a `Ref` object), which requires **contents read**. The narrowed token lacks it, so the query errors, `PR_STATUS` is empty, and the step fails under `set -e -o pipefail`.

## Fix

Add `permission-contents: read` to the `create-github-app-token` block. This restores the ref read while keeping the tighter scoping #194 introduced. `pull-requests: write` still covers reading `reviewDecision` and submitting the approval; `metadata: read` is auto-included by `create-github-app-token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)