### PR TITLE
Set the release title explicitly on gh release create/edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,9 @@ jobs:
       # Create or update, so re-running the workflow on a tag overwrites that
       # release's notes instead of failing.
       #
-      # --title is required, not decoration: `gh release create` omits name from
-      # the request when it is unset and the API has no default for it, so
-      # without this the release is published with a null title and the web UI
-      # falls back to showing the tag.
-      #
-      # On an existing release the current title wins and the tag is only the
-      # fallback, so a title set by hand survives a re-run while one left empty
-      # gets backfilled.
+      # Specify the name (--title) as either the existing name or the ref name.
+      # This is load bearing for our existing release process, as downstream
+      # workflows use the latest release name as the ref to fetch.
       run: |
         if title=$(gh release view "${GITHUB_REF_NAME}" --json name --jq '.name // ""' 2>/dev/null); then
           gh release edit "${GITHUB_REF_NAME}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    # The push trigger is already restricted to v[0-9]+ tags, but
-    # workflow_dispatch is not, and GITHUB_REF_NAME is then a branch name.
-    # action-gh-release used to refuse that case ("GitHub Releases requires a
-    # tag"); `gh release create` would instead happily cut a new tag named after
-    # the branch, so the refusal has to be explicit now.
+    # The push trigger only fires on v[0-9]+ tags, but workflow_dispatch accepts
+    # any ref, and GITHUB_REF_NAME is then a branch name. `gh release create`
+    # would cut a new tag named after that branch rather than refusing, so the
+    # refusal has to be explicit.
     - name: Require a tag
       run: |
         if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
@@ -73,20 +72,18 @@ jobs:
         GH_TOKEN: ${{ steps.gh-api-token.outputs.token }}
         GH_REPO: ${{ github.repository }}
         NOTES_FILE: ${{ runner.temp }}/release_notes.md
-      # Mirrors action-gh-release's create-or-update behaviour: it overwrites
-      # the notes on an existing release rather than failing, which is what
-      # makes re-running this workflow on a tag safe.
+      # Create or update, so re-running the workflow on a tag overwrites that
+      # release's notes instead of failing.
       #
-      # --title is load-bearing. action-gh-release defaulted the release name to
-      # the tag, but `gh release create` omits name from the request entirely
-      # when --title is unset, which leaves the release titled null. On an
-      # existing release the current title wins, so a hand-edited one survives a
-      # re-run and an untitled one gets backfilled -- the same precedence the
-      # action applied (input_name || existing name || tag).
+      # --title is required, not decoration: `gh release create` omits name from
+      # the request when it is unset and the API has no default for it, so
+      # without this the release is published with a null title and the web UI
+      # falls back to showing the tag. Setting it on the edit path too backfills
+      # any release that was already published untitled.
       run: |
-        if title=$(gh release view "${GITHUB_REF_NAME}" --json name --jq '.name // ""' 2>/dev/null); then
+        if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
           gh release edit "${GITHUB_REF_NAME}" \
-            --title "${title:-${GITHUB_REF_NAME}}" \
+            --title "${GITHUB_REF_NAME}" \
             --notes-file "${NOTES_FILE}"
         else
           gh release create "${GITHUB_REF_NAME}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,15 @@ jobs:
       # --title is required, not decoration: `gh release create` omits name from
       # the request when it is unset and the API has no default for it, so
       # without this the release is published with a null title and the web UI
-      # falls back to showing the tag. Setting it on the edit path too backfills
-      # any release that was already published untitled.
+      # falls back to showing the tag.
+      #
+      # On an existing release the current title wins and the tag is only the
+      # fallback, so a title set by hand survives a re-run while one left empty
+      # gets backfilled.
       run: |
-        if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
+        if title=$(gh release view "${GITHUB_REF_NAME}" --json name --jq '.name // ""' 2>/dev/null); then
           gh release edit "${GITHUB_REF_NAME}" \
-            --title "${GITHUB_REF_NAME}" \
+            --title "${title:-${GITHUB_REF_NAME}}" \
             --notes-file "${NOTES_FILE}"
         else
           gh release create "${GITHUB_REF_NAME}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,20 @@ jobs:
       # Mirrors action-gh-release's create-or-update behaviour: it overwrites
       # the notes on an existing release rather than failing, which is what
       # makes re-running this workflow on a tag safe.
+      #
+      # --title is load-bearing. action-gh-release defaulted the release name to
+      # the tag, but `gh release create` omits name from the request entirely
+      # when --title is unset, which leaves the release titled null. On an
+      # existing release the current title wins, so a hand-edited one survives a
+      # re-run and an untitled one gets backfilled -- the same precedence the
+      # action applied (input_name || existing name || tag).
       run: |
-        if gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1; then
-          gh release edit "${GITHUB_REF_NAME}" --notes-file "${NOTES_FILE}"
+        if title=$(gh release view "${GITHUB_REF_NAME}" --json name --jq '.name // ""' 2>/dev/null); then
+          gh release edit "${GITHUB_REF_NAME}" \
+            --title "${title:-${GITHUB_REF_NAME}}" \
+            --notes-file "${NOTES_FILE}"
         else
-          gh release create "${GITHUB_REF_NAME}" --notes-file "${NOTES_FILE}"
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file "${NOTES_FILE}"
         fi


### PR DESCRIPTION
### Why?

#194 replaced `softprops/action-gh-release` with `gh release`, and the release title went with it. The action defaulted the name to the tag, so this workflow never set it explicitly; `gh` omits `name` from the request entirely when `--title` is unset, and the REST API has no default for that field. v2441 published with `"name": null` as a result, and v2442 had to be retitled by hand.

The goal here is behaviour identical to the action, not merely a title that shows up.

### What?

- passes `--title` on `gh release create`, set to the tag
- passes `--title` on `gh release edit`, resolved as the release's current title falling back to the tag, reproducing the action's `input_name || existing name || tag` precedence with the input unset — so a hand-set title survives a re-run and one left empty gets backfilled
- rewrites the two comments in this file to describe what the code does rather than the action it replaced, since nobody reading `release.yml` after this merges will have that context to compare against

The `if`/`else` around create and edit is untouched: they are separate subcommands and each fails in the other's state.

Every other input the old step relied on defaulting was checked against `gh`'s param building and the REST defaults, and all of them already agree: `draft`, `prerelease`, `make_latest`, `target_commitish`, `discussion_category_name`, `generate_release_notes`, and `append_body`. The first commit's message records what each resolves to on both sides.

### Test Plan
- [ ] All changes in PR are covered by tests
- [x] Failures and edge cases tested
- [x] Manually tested any SDK changes

The first box is deliberately unchecked: this repo has no test target a workflow test could hang on, so verification was a local harness rather than anything CI will re-run. The harness extracts the step's `run:` block from `release.yml` and executes it under `bash -e` — the shell Actions uses for `run:` on Linux — against a stubbed `gh`. It reads the script out of the workflow instead of duplicating it, so it cannot drift from the step it covers. The three states the step can encounter, with the expectations encoding the action's precedence:

- no release for the tag → `release create v2443 --title v2443 --notes-file ...`
- release with a hand-edited title → `release edit v2443 --title Hand Written Title --notes-file ...` (preserved, not clobbered)
- release published untitled → `release edit v2443 --title v2443 --notes-file ...` (backfilled)

shellcheck is clean on the extracted block and all four workflow files parse. Every flag was confirmed against `gh release {view,create,edit} --help` on gh 2.92.0, including that `name` is a valid `--json` field. `actionlint` and `zizmor` are not installed locally, so zizmor's run on this PR is the first one against this change.

There are no SDK changes in this PR, which is what makes the third box vacuous rather than skipped.

### See Also

- #194 — replaced the action and introduced the regression
- v2441 still carries `"name": null`; the one-time repair is being handled outside this PR
