### PR TITLE
Dispatch sdk-codegen OpenAPI update workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,13 @@ jobs:
       with:
         app-id: ${{ secrets.GH_APP_STRIPE_OPENAPI_APP_ID }}
         private-key: ${{ secrets.GH_APP_STRIPE_OPENAPI_PRIVATE_KEY }}
-        # The token's only use is dispatching sdk-codegen's codegen workflow,
-        # which needs actions: write on that one repository.
+        # The token's only use is dispatching sdk-codegen's OpenAPI update
+        # workflow, which needs actions: write on that one repository.
         owner: stripe
         repositories: sdk-codegen
         permission-actions: write
 
-    - name: Trigger generated code update
+    - name: Trigger sdk-codegen OpenAPI update
       env:
         GH_API_TOKEN: ${{ steps.gh-api-token.outputs.token }}
       run: |
@@ -47,7 +47,7 @@ jobs:
           -H "Authorization: token ${GH_API_TOKEN}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \
-          https://api.github.com/repos/stripe/sdk-codegen/actions/workflows/codegen.yml/dispatches \
+          https://api.github.com/repos/stripe/sdk-codegen/actions/workflows/update-openapi.yml/dispatches \
           --data '{"ref":"master"}'
     - uses: ./actions/notify-slack
       if: always()


### PR DESCRIPTION
Committed-By-Agent: goose
Orbit-Session-Id: 20de9a97-8cb5-4fc7-8616-b7e23b326d13

Follow up to https://github.com/stripe/sdk-codegen/pull/4001, change the workflow that openapi calls to the update openapi github action instead of codegen. 